### PR TITLE
重构 CaseRunner 进程控制

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,10 @@ class MainWindow(FluentWindow):
                 try:
                     if runner.isRunning():
                         runner.stop()
-                        runner.wait()
+                        if not runner.wait(3000):
+                            runner.quit()
+                            if not runner.wait(1000):
+                                print("runner thread did not finish in time")
                 except Exception:
                     pass
 


### PR DESCRIPTION
## Summary
- 使用 `subprocess.Popen` 重写 `CaseRunner.run`，实时读取 pytest 输出并支持中途停止
- 优化线程停止流程，在 `RunPage.on_back` 与 `MainWindow.clear_run_page` 中采用超时等待

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'uiautomator2')*
- `pip install uiautomator2` *(fails: Could not find a version that satisfies the requirement uiautomator2)*

------
https://chatgpt.com/codex/tasks/task_e_689099843b94832b878d1220ca947450