### PR TITLE
feat: show relative case path in run page

### DIFF
--- a/main.py
+++ b/main.py
@@ -125,10 +125,10 @@ class MainWindow(FluentWindow):
         except Exception as e:
             print(f"FluentWindow.setCurrentWidget error: {e}")
 
-    def on_run(self, case_path, config):
+    def on_run(self, case_path, display_case_path, config):
         self.clear_run_page()
         # 传递主窗口自身作为RunPage的父窗口
-        self.run_page = RunPage(case_path, config, self.show_case_config, parent=self)
+        self.run_page = RunPage(case_path, display_case_path, config, self.show_case_config, parent=self)
         # 确保添加到导航栏和堆叠窗口
         self.addSubInterface(
             self.run_page,

--- a/src/ui/run.py
+++ b/src/ui/run.py
@@ -30,6 +30,8 @@ import re
 import time
 import os
 import random
+import sys
+from pathlib import Path
 class CaseRunner(QThread):
     """Thread to run pytest and emit log output"""
 
@@ -124,7 +126,7 @@ class CaseRunner(QThread):
 class RunPage(CardWidget):
     """运行页"""
 
-    def __init__(self, case_path, config, on_back_callback, parent=None):
+    def __init__(self, case_path, display_case_path=None, config=None, on_back_callback=None, parent=None):
         super().__init__(parent)
         self.setObjectName("runPage")
         self.case_path = case_path
@@ -132,9 +134,14 @@ class RunPage(CardWidget):
         self.on_back_callback = on_back_callback
         self.main_window = parent  # 保存主窗口引用（用于InfoBar父窗口）
 
+        if display_case_path is None:
+            app_base = self._get_application_base()
+            display_case_path = os.path.relpath(os.path.abspath(case_path), app_base)
+        self.display_case_path = display_case_path
+
         layout = QVBoxLayout(self)
         layout.setSpacing(16)
-        layout.addWidget(StrongBodyLabel(f"正在运行：{case_path}"))
+        layout.addWidget(StrongBodyLabel(f"正在运行：{self.display_case_path}"))
 
         self.progress = ProgressBar(self)
         self.progress.setValue(0)
@@ -258,3 +265,7 @@ class RunPage(CardWidget):
             pass
 
         self.on_back_callback()  # 调用返回配置页的回调
+
+    def _get_application_base(self) -> str:
+        """获取应用根路径"""
+        return getattr(sys, "_MEIPASS", str(Path(__file__).resolve().parent.parent))

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -753,10 +753,11 @@ class CaseConfigPage(CardWidget):
         src_idx = model.mapToSource(proxy_idx) if isinstance(model, QSortFilterProxyModel) else proxy_idx
         selected_path = self.fs_model.filePath(src_idx)
         if os.path.isfile(selected_path) and selected_path.endswith(".py"):
+            selected_path = Path(selected_path).resolve()
             try:
-                case_path = os.path.relpath(selected_path, app_base)
+                case_path = os.path.relpath(str(selected_path), app_base)
             except ValueError:
-                case_path = selected_path
+                case_path = str(selected_path)
         # 将最终运行的用例路径写入配置（尽量保持相对路径）
         self.config["text_case"] = case_path
         # 解析成绝对路径
@@ -764,7 +765,7 @@ class CaseConfigPage(CardWidget):
         # 保存配置
         self._save_config()
         if os.path.isfile(abs_case_path) and abs_case_path.endswith(".py"):
-            self.on_run_callback(abs_case_path, self.config)
+            self.on_run_callback(abs_case_path, case_path, self.config)
         else:
             InfoBar.warning(
                 title="提示",


### PR DESCRIPTION
## Summary
- 规范运行前用例路径并同时传递绝对路径与相对路径
- RunPage 支持显示相对路径并在缺省时自动计算

## Testing
- `python - <<'PY'
import os, sys
from pathlib import Path
app_base = str(Path('src').resolve())
case_path = '/workspace/wifi_test/src/test/test_Wifi_Sanity_Compatibility.py'
print('app_base:', app_base)
print('abs case:', os.path.abspath(case_path))
print('rel:', os.path.relpath(os.path.abspath(case_path), app_base))
PY`
- `pip install PyQt5 qfluentwidgets -q` *(fails: Could not find a version that satisfies the requirement PyQt5)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689160e3d5e0832b9b2b7e99da7784ff