### PR TITLE
feat: normalize application base path

### DIFF
--- a/src/ui/run.py
+++ b/src/ui/run.py
@@ -268,4 +268,9 @@ class RunPage(CardWidget):
 
     def _get_application_base(self) -> str:
         """获取应用根路径"""
-        return getattr(sys, "_MEIPASS", str(Path(__file__).resolve().parent.parent))
+        base = (
+            Path(sys._MEIPASS) / "src"
+            if hasattr(sys, "_MEIPASS")
+            else Path(__file__).resolve().parent.parent
+        )
+        return str(base.resolve())

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -241,7 +241,12 @@ class CaseConfigPage(CardWidget):
 
     def _get_application_base(self) -> str:
         """获取应用根路径"""
-        return getattr(sys, "_MEIPASS", str(Path(__file__).resolve().parent.parent))
+        base = (
+            Path(sys._MEIPASS) / "src"
+            if hasattr(sys, "_MEIPASS")
+            else Path(__file__).resolve().parent.parent
+        )
+        return str(base.resolve())
 
     def _resolve_case_path(self, path: str) -> str:
         """将相对用例路径转换为绝对路径"""


### PR DESCRIPTION
## Summary
- adjust `_get_application_base` to resolve to `src` under both source and PyInstaller environments

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'uiautomator2')*


------
https://chatgpt.com/codex/tasks/task_e_689167ad22ac832bb47bd564dfadc5f6