### PR TITLE
fix: ensure src package importable

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -8,7 +8,8 @@
 # Description：
 """
 
-import os
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import re
 import shutil
 import subprocess
@@ -27,7 +28,6 @@ from src.tools.router_tool.Router import Router
 test_results = []
 
 import logging
-import sys
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary
- 在 `src/conftest.py` 中插入项目根目录到 `sys.path`，使 `src` 包可以被导入。

## Testing
- `pytest -q`（命令不存在）
- `pip install --break-system-packages pytest`（代理限制，无法下载 pytest）

------
https://chatgpt.com/codex/tasks/task_e_68933f6159a4832b9d8c0b055853401a