### PR TITLE
feat: redirect performance cases to wifi config

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -128,9 +128,12 @@ class MainWindow(FluentWindow):
         # 确保窗口顶部不会超出屏幕
         self.move(window_geometry.topLeft())
 
-    def setCurrentIndex(self, page_widget):
+    def setCurrentIndex(self, page_widget, ssid: str | None = None, passwd: str | None = None):
         # print("setCurrentIndex dir:", dir(self))
         try:
+            if page_widget is self.rvr_wifi_config_page and (ssid or passwd):
+                if hasattr(self.rvr_wifi_config_page, "set_router_credentials"):
+                    self.rvr_wifi_config_page.set_router_credentials(ssid or "", passwd or "")
             self.stackedWidget.setCurrentWidget(page_widget)
             print(f"FluentWindow.setCurrentWidget({page_widget}) success")
         except Exception as e:

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -173,6 +173,20 @@ class RvrWifiConfigPage(CardWidget):
                 widget.addItems(options)
                 widget.blockSignals(False)
 
+    def set_router_credentials(self, ssid: str, passwd: str) -> None:
+        try:
+            ssid_col = self.headers.index("ssid") + 1
+            passwd_col = self.headers.index("wpa_passwd") + 1
+        except ValueError:
+            return
+        for r in range(self.table.rowCount()):
+            ssid_cell = self.table.cellWidget(r, ssid_col)
+            if isinstance(ssid_cell, LineEdit):
+                ssid_cell.setText(ssid)
+            passwd_cell = self.table.cellWidget(r, passwd_col)
+            if isinstance(passwd_cell, LineEdit):
+                passwd_cell.setText(passwd)
+
     # ------------------------------------------------------------------
     # 保存
     def save_csv(self):

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -728,6 +728,22 @@ class CaseConfigPage(CardWidget):
             self.case_tree.setEnabled(True)
             self._refreshing = False
 
+        base = Path(self._get_application_base())
+        perf_dir = (base / "test" / "performance").resolve()
+        case_abs = Path(case_path).resolve() if case_path else None
+        if case_abs and perf_dir in case_abs.parents:
+            ssid = ""
+            passwd = ""
+            ssid_widget = self.field_widgets.get("router.ssid")
+            if isinstance(ssid_widget, LineEdit):
+                ssid = ssid_widget.text()
+            passwd_widget = self.field_widgets.get("router.wpa_passwd")
+            if isinstance(passwd_widget, LineEdit):
+                passwd = passwd_widget.text()
+            main_window = self.window()
+            if hasattr(main_window, "setCurrentIndex"):
+                main_window.setCurrentIndex(main_window.rvr_wifi_config_page, ssid, passwd)
+
         # 若用户在刷新过程中又点了别的用例，延迟 0 ms 处理它
         if self._pending_path:
             path = self._pending_path


### PR DESCRIPTION
## Summary
- auto-switch to RVR Wi-Fi configuration when selecting performance test case
- forward router SSID/password via MainWindow
- allow RvrWiFiConfigPage to receive SSID and password

## Testing
- `python -m py_compile src/ui/windows_case_config.py src/main.py src/ui/rvr_wifi_config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uiautomator2')*


------
https://chatgpt.com/codex/tasks/task_e_68934548a680832b8eb79eddc0880295