### PR TITLE
feat: sync RVR Wi-Fi page with router settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,9 +38,10 @@ class MainWindow(FluentWindow):
 
         # 页面实例化
         self.case_config_page = CaseConfigPage(self.on_run)
-        info = self.case_config_page.get_router_wifi_info()
-        self.rvr_wifi_config_page = RvrWifiConfigPage(*info)
-        self.case_config_page.routerInfoChanged.connect(self.rvr_wifi_config_page.update_wifi_info)
+        self.rvr_wifi_config_page = RvrWifiConfigPage(self.case_config_page)
+        self.case_config_page.routerInfoChanged.connect(
+            self.rvr_wifi_config_page.update_wifi_info
+        )
         self.run_page = None  # 运行窗口动态加载
 
         # 添加侧边导航（页面，图标，标题，描述）

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -24,18 +24,22 @@ from qfluentwidgets import (
 )
 
 from src.tools.router_tool.router_factory import get_router
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .windows_case_config import CaseConfigPage
 
 
 class RvrWifiConfigPage(CardWidget):
     """配置 RVR Wi-Fi 测试参数"""
 
-    def __init__(self, ssid_2g: str = "", passwd_2g: str = "", ssid_5g: str = "", passwd_5g: str = ""):
+    def __init__(self, case_config_page: "CaseConfigPage"):
         super().__init__()
         self.setObjectName("rvrWifiConfigPage")
-        self.ssid_2g = ssid_2g
-        self.passwd_2g = passwd_2g
-        self.ssid_5g = ssid_5g
-        self.passwd_5g = passwd_5g
+        self.case_config_page = case_config_page
+        self.ssid_2g, self.passwd_2g, self.ssid_5g, self.passwd_5g = (
+            case_config_page.get_router_wifi_info()
+        )
 
         # -------------------- paths --------------------
         base = Path.cwd()
@@ -110,7 +114,10 @@ class RvrWifiConfigPage(CardWidget):
                 row["ssid"] = self.ssid_5g
                 row["wpa_passwd"] = self.passwd_5g
 
-    def update_wifi_info(self, ssid_2g: str, passwd_2g: str, ssid_5g: str, passwd_5g: str):
+    def update_wifi_info(self):
+        ssid_2g, passwd_2g, ssid_5g, passwd_5g = (
+            self.case_config_page.get_router_wifi_info()
+        )
         self.ssid_2g = ssid_2g
         self.passwd_2g = passwd_2g
         self.ssid_5g = ssid_5g

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -77,7 +77,7 @@ class TestFileFilterModel(QSortFilterProxyModel):
 class CaseConfigPage(CardWidget):
     """用例配置主页面"""
 
-    routerInfoChanged = pyqtSignal(str, str, str, str)
+    routerInfoChanged = pyqtSignal()
 
     def __init__(self, on_run_callback):
         super().__init__()
@@ -312,7 +312,7 @@ class CaseConfigPage(CardWidget):
 
     def on_router_changed(self, name: str):
         self._load_router_wifi_info(name)
-        self.routerInfoChanged.emit(*self.get_router_wifi_info())
+        self.routerInfoChanged.emit()
 
     def render_all_fields(self):
         """


### PR DESCRIPTION
## Summary
- 初始化 RVR Wi-Fi 页面时自动读取 CaseConfigPage 的 Wi-Fi 信息
- CaseConfigPage 的 routerInfoChanged 信号改为无参触发
- 主窗口随信号刷新 RVR Wi-Fi 配置

## Testing
- `python -m py_compile src/ui/rvr_wifi_config.py src/ui/windows_case_config.py src/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uiautomator2')*
- `pip install uiautomator2` *(fails: Could not find a version that satisfies the requirement uiautomator2)*

------
https://chatgpt.com/codex/tasks/task_e_68934b56ab8c832b8de647eeccdddda1