### PR TITLE
feat: 控制 RVR Wi-Fi 配置页显隐

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -48,14 +48,29 @@ class MainWindow(FluentWindow):
         self.addSubInterface(
             self.case_config_page, FluentIcon.SETTING, "用例配置", "Case Config"
         )
-        self.addSubInterface(
-            self.rvr_wifi_config_page, FluentIcon.WIFI, "RVR Wi-Fi配置", "RVR Wi-Fi Config"
-        )
+        # 初始不展示 RVR Wi-Fi 配置页
         # 可加更多页面，比如“历史记录”“关于”等
 
         # FluentWindow自带自定义颜色与主题
         setTheme(Theme.LIGHT)  # 或 Theme.LIGHT
         # self.setMicaEffectEnabled(True)  # Win11下生效毛玻璃
+
+    def show_rvr_wifi_config(self):
+        """在导航栏中显示 RVR Wi-Fi 配置页"""
+        if self.stackedWidget.indexOf(self.rvr_wifi_config_page) == -1:
+            self.addSubInterface(
+                self.rvr_wifi_config_page,
+                FluentIcon.WIFI,
+                "RVR Wi-Fi配置",
+                "RVR Wi-Fi Config",
+            )
+
+    def hide_rvr_wifi_config(self):
+        """从导航栏移除 RVR Wi-Fi 配置页"""
+        self.removeSubInterface(self.rvr_wifi_config_page)
+        index = self.stackedWidget.indexOf(self.rvr_wifi_config_page)
+        if index != -1:
+            self.stackedWidget.removeWidget(self.rvr_wifi_config_page)
 
     def removeSubInterface(self, page):
         """Remove the given page from the navigation if possible."""

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -787,6 +787,7 @@ class CaseConfigPage(CardWidget):
         base = Path(self._get_application_base())
         perf_dir = (base / "test" / "performance").resolve()
         case_abs = Path(case_path).resolve() if case_path else None
+        main_window = self.window()
         if case_abs and perf_dir in case_abs.parents:
             ssid = ""
             passwd = ""
@@ -796,9 +797,15 @@ class CaseConfigPage(CardWidget):
             passwd_widget = self.field_widgets.get("router.wpa_passwd")
             if isinstance(passwd_widget, LineEdit):
                 passwd = passwd_widget.text()
-            main_window = self.window()
+            if hasattr(main_window, "show_rvr_wifi_config"):
+                main_window.show_rvr_wifi_config()
             if hasattr(main_window, "setCurrentIndex"):
                 main_window.setCurrentIndex(main_window.rvr_wifi_config_page, ssid, passwd)
+        else:
+            if hasattr(main_window, "hide_rvr_wifi_config"):
+                main_window.hide_rvr_wifi_config()
+            if hasattr(main_window, "setCurrentIndex"):
+                main_window.setCurrentIndex(main_window.case_config_page)
 
         # 若用户在刷新过程中又点了别的用例，延迟 0 ms 处理它
         if self._pending_path:


### PR DESCRIPTION
## Summary
- 新增方法用以动态显示/隐藏 RVR Wi-Fi 配置页
- 根据所选用例路径自动切换或隐藏 RVR Wi-Fi 配置页

## Testing
- `pytest` *(失败: No module named 'uiautomator2')*


------
https://chatgpt.com/codex/tasks/task_e_6893f303f2f0832b816a2e53cc8bf69c