### PR TITLE
feat: 支持表格内部拖拽排序

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -43,13 +43,18 @@ class WifiTableWidget(TableWidget):
     def __init__(self, page: "RvrWifiConfigPage"):
         super().__init__(page)
         self.page = page
-        # 行内数据不允许单独选中
-        self.setSelectionMode(QAbstractItemView.NoSelection)
+        # 仅允许单行选择并整行高亮
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
         # 垂直表头允许拖动以调整行顺序
         vh = self.verticalHeader()
         vh.setVisible(True)
         vh.setSectionsMovable(True)
         vh.sectionMoved.connect(lambda *_: self.page._sync_rows())
+        # 启用内部拖拽排序
+        self.setDragDropMode(QAbstractItemView.InternalMove)
+        self.setDragEnabled(True)
+        self.setAcceptDrops(True)
 
     # 仍保留 dropEvent 以兼容内部拖拽
     def dropEvent(self, event):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- 表格仅允许单行选择并整行高亮
- 启用表格内部拖拽排序并在拖动后同步数据

## Testing
- `pytest` *(因 KeyboardInterrupt 中止)*

------
https://chatgpt.com/codex/tasks/task_e_6893ff061de8832bbd9972a04268416b