### PR TITLE
改进Wi-Fi配置表格列宽自适应

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -19,6 +19,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QCheckBox,
     QAbstractItemView,
+    QHeaderView,
 )
 from qfluentwidgets import (
     CardWidget,
@@ -135,6 +136,9 @@ class RvrWifiConfigPage(CardWidget):
         self.table = WifiTableWidget(self)
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Stretch)
+        header.setStretchLastSection(True)
         main_layout.addWidget(self.table, 2)
 
         self.band_combo.currentTextChanged.connect(self._update_band_options)


### PR DESCRIPTION
## Summary
- 导入 `QHeaderView` 并设置 Wi-Fi 配置表格列宽自适应填充

## Testing
- `pytest` *(failed: no option named '--linux-only')*

------
https://chatgpt.com/codex/tasks/task_e_6893ff00f798832ba7d39e5b060572e6