### PR TITLE
移除 RVR Wi-Fi 配置中的预期速率字段

### DIFF
--- a/config/rvr_wifi_setup.csv
+++ b/config/rvr_wifi_setup.csv
@@ -1,4 +1,4 @@
-band,ssid,wireless_mode,channel,bandwidth,authentication,password,tx,rx,data_row,expected_rate_tx,expected_rate_rx
-5 GHz,coco,11ax,36,40MHz,强加密(WPA2个人版),12345678,1,0,5,10,10
-2.4 GHz,coco,11ax,13,40MHz,强加密(WPA2个人版),12345678,1,1,5,10,10
-2.4 GHz,coco,11ax,13,40MHz,强加密(WPA2个人版),12345678,1,1,5,10,10
+band,ssid,wireless_mode,channel,bandwidth,authentication,password,tx,rx,data_row
+5 GHz,coco,11ax,36,40MHz,强加密(WPA2个人版),12345678,1,0,5
+2.4 GHz,coco,11ax,13,40MHz,强加密(WPA2个人版),12345678,1,1,5
+2.4 GHz,coco,11ax,13,40MHz,强加密(WPA2个人版),12345678,1,1,5

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -117,12 +117,6 @@ class RvrWifiConfigPage(CardWidget):
         self.data_row_edit = LineEdit(form_box)
         form_layout.addRow("data_row", self.data_row_edit)
 
-        self.expected_rate_tx_edit = LineEdit(form_box)
-        form_layout.addRow("expected_rate_tx", self.expected_rate_tx_edit)
-
-        self.expected_rate_rx_edit = LineEdit(form_box)
-        form_layout.addRow("expected_rate_rx", self.expected_rate_rx_edit)
-
         btn_widget = QWidget(form_box)
         btn_layout = QHBoxLayout(btn_widget)
         btn_layout.setContentsMargins(0, 0, 0, 0)
@@ -180,8 +174,6 @@ class RvrWifiConfigPage(CardWidget):
             "tx",
             "rx",
             "data_row",
-            "expected_rate_tx",
-            "expected_rate_rx",
         ]
         rows: list[dict[str, str]] = []
         if self.csv_path.exists():
@@ -278,8 +270,6 @@ class RvrWifiConfigPage(CardWidget):
             "tx": "1" if self.tx_check.isChecked() else "0",
             "rx": "1" if self.rx_check.isChecked() else "0",
             "data_row": self.data_row_edit.text(),
-            "expected_rate_tx": self.expected_rate_tx_edit.text(),
-            "expected_rate_rx": self.expected_rate_rx_edit.text(),
         }
         self.rows.append(row)
         self.refresh_table()


### PR DESCRIPTION
## Summary
- 删除 `expected_rate_tx` 与 `expected_rate_rx` 编辑框及相关逻辑
- 精简 CSV 头部及新增行，去除预期速率字段
- 更新示例配置文件以匹配新的字段列表

## Testing
- `python -m pytest -q` *(收集阶段出现 244 个错误，测试未能完成)*

------
https://chatgpt.com/codex/tasks/task_e_6894132edcf4832b877fc5c77b359180