### PR TITLE
优化认证列宽显示

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -103,6 +103,7 @@ class RvrWifiConfigPage(CardWidget):
 
         self.auth_combo = ComboBox(form_box)
         self.auth_combo.addItems(getattr(self.router, "AUTHENTICATION_METHOD", []))
+        self.auth_combo.setMinimumWidth(150)
         form_layout.addRow("authentication", self.auth_combo)
 
         test_widget = QWidget(form_box)
@@ -141,6 +142,10 @@ class RvrWifiConfigPage(CardWidget):
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.Stretch)
         header.setStretchLastSection(True)
+        self.table.horizontalHeader().setSectionResizeMode(
+            self.headers.index("authentication"), QHeaderView.ResizeToContents
+        )
+        self.table.setColumnWidth(self.headers.index("authentication"), 150)
         main_layout.addWidget(self.table, 2)
 
         self.band_combo.currentTextChanged.connect(self._update_band_options)


### PR DESCRIPTION
## Summary
- 让 `auth_combo` 输入框具备最小宽度
- `authentication` 列宽根据内容自适应，并指定最小宽度

## Testing
- `python -m py_compile src/ui/rvr_wifi_config.py`
- `pytest -q` *(失败: adb: not found; FileNotFoundError: pytest.log)*

------
https://chatgpt.com/codex/tasks/task_e_689418d1ab30832b91c8b9dffd6b8d70