### PR TITLE
fix: ensure csv selection uses absolute path

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -281,7 +281,8 @@ class RvrWifiConfigPage(CardWidget):
         """响应 CSV 文件变更"""
         if not path:
             return
-        self.csv_path = Path(path)
+        # 确保使用绝对路径加载 CSV，避免目录切换引起的混淆
+        self.csv_path = Path(path).resolve()
         self.reload_csv()
         self._loading = True
         try:

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -877,8 +877,10 @@ class CaseConfigPage(CardWidget):
         if index < 0:
             self.selected_csv_path = None
             return
-        self.selected_csv_path = self.csv_combo.itemData(index)
-        self.csvFileChanged.emit(self.selected_csv_path)
+        # 统一转换为绝对路径，避免重复文件名导致加载错误
+        data = self.csv_combo.itemData(index)
+        self.selected_csv_path = str(Path(data).resolve()) if data else None
+        self.csvFileChanged.emit(self.selected_csv_path or "")
 
     def on_run(self):
         # 将字段值更新到 self.config（保持结构）


### PR DESCRIPTION
## Summary
- convert selected csv path to an absolute path before emitting change signal
- resolve incoming csv paths in RVR Wi-Fi config page

## Testing
- `pytest -q` *(fails: Interrupted: 282 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689830beb280832b89771aa6ef78fdc9