### PR TITLE
fix: ensure csv selection uses absolute path

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -229,16 +229,19 @@ class RvrWifiConfigPage(CardWidget):
         ]
         headers = default_headers
         rows: list[dict[str, str]] = []
+        print(f"_load_csv path={self.csv_path}")
         if self.csv_path.exists():
             with open(self.csv_path, newline="", encoding="utf-8") as f:
                 reader = csv.DictReader(f)
                 headers = reader.fieldnames or default_headers
                 for row in reader:
                     rows.append({h: row.get(h, "") for h in headers})
+        print(f"_load_csv headers={headers} rows={len(rows)}")
         return headers, rows
 
     def reload_csv(self):
         """重新读取当前 CSV 并刷新表格"""
+        print(f"reload_csv using {self.csv_path}")
         self.headers, self.rows = self._load_csv()
         self.refresh_table()
 
@@ -281,7 +284,10 @@ class RvrWifiConfigPage(CardWidget):
         """响应 CSV 文件变更"""
         if not path:
             return
-        self.csv_path = Path(path)
+        # 确保使用绝对路径加载 CSV，避免目录切换引起的混淆
+        print(f"on_csv_file_changed path={path}")
+        self.csv_path = Path(path).resolve()
+        print(f"resolved csv_path={self.csv_path}")
         self.reload_csv()
         self._loading = True
         try:

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -347,10 +347,12 @@ class CaseConfigPage(CardWidget):
         else:
             csv_dir = None
         logging.debug("_update_csv_options %s", csv_dir)
+        print(f"_update_csv_options router={router_name} dir={csv_dir}")
         with QSignalBlocker(self.csv_combo):
             self.csv_combo.clear()
             if csv_dir and csv_dir.exists():
                 for csv_file in sorted(csv_dir.glob("*.csv")):
+                    print(f"found csv: {csv_file}")
                     self.csv_combo.addItem(csv_file.name, str(csv_file.resolve()))
                 self.csv_combo.setCurrentIndex(-1)
         self.selected_csv_path = None
@@ -877,8 +879,12 @@ class CaseConfigPage(CardWidget):
         if index < 0:
             self.selected_csv_path = None
             return
-        self.selected_csv_path = self.csv_combo.itemData(index)
-        self.csvFileChanged.emit(self.selected_csv_path)
+        # 统一转换为绝对路径，避免重复文件名导致加载错误
+        data = self.csv_combo.itemData(index)
+        print(f"on_csv_changed index={index} data={data}")
+        self.selected_csv_path = str(Path(data).resolve()) if data else None
+        print(f"selected_csv_path={self.selected_csv_path}")
+        self.csvFileChanged.emit(self.selected_csv_path or "")
 
     def on_run(self):
         # 将字段值更新到 self.config（保持结构）


### PR DESCRIPTION
## Summary
- convert selected csv path to an absolute path before emitting change signal
- resolve incoming csv paths in RVR Wi-Fi config page
- add debug prints to trace csv directory scanning and selection

## Testing
- `pytest -q` *(fails: Interrupted: 282 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689830beb280832b89771aa6ef78fdc9