### PR TITLE
refactor: centralize constants and adjust pytest rootdir

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@
 # -*-coding:utf-8 -*-
 
 import sys
-import os
 from pathlib import Path
 import traceback
 import logging
@@ -18,6 +17,7 @@ from src.ui.run import RunPage
 from qfluentwidgets import setTheme, Theme
 from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtCore import QCoreApplication
+from src.util.constants import Paths
 
 
 def log_exception(exc_type, exc_value, exc_tb):
@@ -154,20 +154,6 @@ class MainWindow(FluentWindow):
         QCoreApplication.processEvents()  # 强制事件刷新
         self.clear_run_page()
         print("Switched to CaseConfigPage")
-
-
-def get_base_dir():
-    """返回程序所在的基础目录（打包后是 exe 所在目录）"""
-    if getattr(sys, 'frozen', False):
-        return os.path.dirname(sys.executable)  # 打包后的路径
-    else:
-        return os.path.dirname(os.path.dirname(__file__))  # 开发时的项目根目录
-
-
-# 关键路径定义
-BASE_DIR = get_base_dir()
-CONFIG_DIR = os.path.join(BASE_DIR, "config")  # 共享的 config 目录
-RES_DIR = os.path.join(BASE_DIR, "res")  # 共享的 res 目录
 
 sys.excepthook = log_exception
 

--- a/src/dut_control/roku_ctrl.py
+++ b/src/dut_control/roku_ctrl.py
@@ -23,48 +23,7 @@ from roku import Roku
 from src.tools.connect_tool.serial_tool import serial_tool
 from src.tools.connect_tool.telnet_tool import telnet_tool
 from src.tools.yamlTool import yamlTool
-
-COMMANDS = {
-    # Standard Keys
-    "home": "Home",
-    "reverse": "Rev",
-    "forward": "Fwd",
-    "play": "Play",
-    "select": "Select",
-    "left": "Left",
-    "right": "Right",
-    "down": "Down",
-    "up": "Up",
-    "back": "Back",
-    "replay": "InstantReplay",
-    "info": "Info",
-    "backspace": "Backspace",
-    "search": "Search",
-    "enter": "Enter",
-    "literal": "Lit",
-    # For devices that support "Find Remote"
-    "find_remote": "FindRemote",
-    # For Roku TV
-    "volume_down": "VolumeDown",
-    "volume_up": "VolumeUp",
-    "volume_mute": "VolumeMute",
-    # For Roku TV while on TV tuner channel
-    "channel_up": "ChannelUp",
-    "channel_down": "ChannelDown",
-    # For Roku TV current input
-    "input_tuner": "InputTuner",
-    "input_hdmi1": "InputHDMI1",
-    "input_hdmi2": "InputHDMI2",
-    "input_hdmi3": "InputHDMI3",
-    "input_hdmi4": "InputHDMI4",
-    "input_av1": "InputAV1",
-    # For devices that support being turned on/off
-    "power": "Power",
-    "poweroff": "PowerOff",
-    "poweron": "PowerOn",
-}
-
-SENSORS = ("acceleration", "magnetic", "orientation", "rotation")
+from src.util.constants import RokuConst
 
 # roku_lux = YamlTool(os.getcwd() + '/config/roku/roku_changhong.yaml')
 roku_config = yamlTool(os.getcwd() + '/config/config.yaml')
@@ -189,17 +148,17 @@ class roku_ctrl(Roku):
     #                                 ['Legal notices'], ['Privacy'], ['Help'], ['System']]
 
     def __getattr__(self, name):
-        # if name not in COMMANDS and name not in SENSORS:
+        # if name not in RokuConst.COMMANDS and name not in RokuConst.SENSORS:
         #     raise AttributeError(f"{name} is not a valid method")
 
         def command(*args, **kwargs):
-            if name in SENSORS:
+            if name in RokuConst.SENSORS:
                 keys = [f"{name}.{axis}" for axis in ("x", "y", "z")]
                 params = dict(zip(keys, args))
                 self.input(params)
             elif name == "literal":
                 for char in args[0]:
-                    path = f"/keypress/{COMMANDS[name]}_{quote_plus(char)}"
+                    path = f"/keypress/{RokuConst.COMMANDS[name]}_{quote_plus(char)}"
                     self._post(path)
             elif name == "search":
                 path = "/search/browse"
@@ -207,11 +166,11 @@ class roku_ctrl(Roku):
                 self._post(path, params=params)
             else:
                 if len(args) > 0 and (args[0] == "keydown" or args[0] == "keyup"):
-                    path = f"/{args[0]}/{COMMANDS[name]}"
+                    path = f"/{args[0]}/{RokuConst.COMMANDS[name]}"
                     logging.info(f'key {args[0]}')
                 else:
-                    path = f"/keypress/{COMMANDS[name]}"
-                    logging.info(f'Press key {COMMANDS[name]}')
+                    path = f"/keypress/{RokuConst.COMMANDS[name]}"
+                    logging.info(f'Press key {RokuConst.COMMANDS[name]}')
                 try:
                     self._post(path)
                 except Exception:
@@ -1082,7 +1041,7 @@ class roku_ctrl(Roku):
         button_dict = {'h': 'home', 'p': 'play', 's': 'select', 'l': 'left', 'r': 'right', 'd': 'down', 'u': 'up',
                        'b': 'back', 'i': 'info'}
         for i in button_list:
-            if i in COMMANDS:
+            if i in RokuConst.COMMANDS:
                 getattr(self, button_dict[i])(time=idle)
             else:
                 logging.info(f'{i} not in button_dict .pls check again')

--- a/src/test/stress/test_compatibility.py
+++ b/src/test/stress/test_compatibility.py
@@ -17,7 +17,8 @@ import pytest
 
 from src.tools.pdusnmp import power_ctrl
 from src.tools.router_tool.Router import Router
-from src.tools.router_tool.router_performance import FPGA_CONFIG, compatibility_router
+from src.tools.router_tool.router_performance import compatibility_router
+from src.util.constants import RouterConst
 
 power_delay = power_ctrl()
 power_ctrl = power_delay.ctrl
@@ -56,8 +57,8 @@ def handle_expectdata(ip, port, band, dir):
             authentication = data[band]['authentication']
             with open(f"{os.getcwd()}/config/compatibility_dut.json", 'r') as f:
                 dut_data = json.load(f)
-                return dut_data[band][interface.upper()][FPGA_CONFIG[wifichip][band]][bandwidth][
-                    FPGA_CONFIG[wifichip]['mimo']][
+                return dut_data[band][interface.upper()][RouterConst.FPGA_CONFIG[wifichip][band]][bandwidth][
+                    RouterConst.FPGA_CONFIG[wifichip]['mimo']][
                     dir]
 
 

--- a/src/tools/router_tool/Router.py
+++ b/src/tools/router_tool/Router.py
@@ -9,6 +9,7 @@
 """
 
 from collections import namedtuple
+from src.util.constants import RouterConst
 
 
 def _info(info):
@@ -19,13 +20,8 @@ def router_str(self):
     return f'{_info(self.band)},{_info(self.ssid)},{_info(self.wireless_mode)},{_info(self.channel)},{_info(self.bandwidth)},{_info(self.authentication)}'
 
 
-RUN_SETTING_ACTIVITY = 'am start -n com.android.tv.settings/.MainSettings'
-
-fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
-          'password', 'tx', 'rx', 'data_row', 'expected_rate', 'wifi6', 'wep_encrypt',
-          'hide_ssid', 'hide_type', 'wpa_encrypt', 'passwd_index', 'protect_frame',
-          'smart_connect', 'country_code']
-
+RUN_SETTING_ACTIVITY = RouterConst.RUN_SETTING_ACTIVITY
+fields = RouterConst.fields
 Router = namedtuple('Router', fields, defaults=(None,) * len(fields))
 Router.__str__ = router_str
 Router.__repr__ = router_str

--- a/src/tools/router_tool/router_performance.py
+++ b/src/tools/router_tool/router_performance.py
@@ -15,16 +15,9 @@ import os
 import json
 from typing import Literal
 from src.util.mixin import json_mixin, nested_dict
+from src.util.constants import RouterConst
 
-FPGA_CONFIG = {
-    'W1': {'mimo': '1X1', '2.4G': '11N', '5G': '11AC'},
-    'W1L': {'mimo': '1X1', '2.4G': '11N', '5G': '11AC'},
-    'W2': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'},
-    'W2U': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'},
-    'W2L': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'}
-}
-dut_wifichip = 'w2_sdio'
-wifichip, interface = dut_wifichip.split('_')
+wifichip, interface = RouterConst.dut_wifichip.split('_')
 
 
 @dataclass
@@ -337,7 +330,7 @@ def handle_expectdata(ip, port, band, dir):
             authentication = data[band]['authentication']
             with open(f"{os.getcwd()}/config/compatibility_dut.json", 'r') as f:
                 dut_data = json.load(f)
-                return dut_data[band][interface][FPGA_CONFIG[wifichip][band]][bandwidth][FPGA_CONFIG[wifichip]['mimo']][
+                return dut_data[band][interface][RouterConst.FPGA_CONFIG[wifichip][band]][bandwidth][RouterConst.FPGA_CONFIG[wifichip]['mimo']][
                     dir]
 
 # print(handle_expectdata("192.168.200.6", "7", '2.4G', 'UL'))

--- a/src/ui/run.py
+++ b/src/ui/run.py
@@ -86,6 +86,7 @@ class CaseRunner(QThread):
                 "-v",
                 "-s",
                 "--full-trace",
+                "--rootdir=.",
                 f"--resultpath={report_dir}",
                 self.case_path,
             ]

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -3,3 +3,7 @@
 # @Time    : 2024/8/27 14:43
 # @Author  : chao.li
 # @File    : __init__.py.py
+
+from .constants import Paths, RouterConst, RokuConst
+
+__all__ = ["Paths", "RouterConst", "RokuConst"]

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -1,0 +1,79 @@
+import os
+import sys
+from pathlib import Path
+from typing import Final
+
+
+class Paths:
+    """项目路径常量"""
+    if getattr(sys, "frozen", False):
+        BASE_DIR: Final[str] = os.path.dirname(sys.executable)
+    else:
+        BASE_DIR: Final[str] = str(Path(__file__).resolve().parents[2])
+    CONFIG_DIR: Final[str] = os.path.join(BASE_DIR, "config")
+    RES_DIR: Final[str] = os.path.join(BASE_DIR, "res")
+
+
+class RouterConst:
+    """路由器相关常量"""
+    RUN_SETTING_ACTIVITY: Final[str] = 'am start -n com.android.tv.settings/.MainSettings'
+    fields: Final[list[str]] = [
+        'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+        'password', 'tx', 'rx', 'data_row', 'expected_rate', 'wifi6', 'wep_encrypt',
+        'hide_ssid', 'hide_type', 'wpa_encrypt', 'passwd_index', 'protect_frame',
+        'smart_connect', 'country_code'
+    ]
+    FPGA_CONFIG: Final[dict] = {
+        'W1': {'mimo': '1X1', '2.4G': '11N', '5G': '11AC'},
+        'W1L': {'mimo': '1X1', '2.4G': '11N', '5G': '11AC'},
+        'W2': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'},
+        'W2U': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'},
+        'W2L': {'mimo': '2X2', '2.4G': '11AX', '5G': '11AX'}
+    }
+    dut_wifichip: Final[str] = 'w2_sdio'
+
+
+class RokuConst:
+    """Roku 控制常量"""
+    COMMANDS: Final[dict[str, str]] = {
+        # Standard Keys
+        "home": "Home",
+        "reverse": "Rev",
+        "forward": "Fwd",
+        "play": "Play",
+        "select": "Select",
+        "left": "Left",
+        "right": "Right",
+        "down": "Down",
+        "up": "Up",
+        "back": "Back",
+        "replay": "InstantReplay",
+        "info": "Info",
+        "backspace": "Backspace",
+        "search": "Search",
+        "enter": "Enter",
+        "literal": "Lit",
+        # For devices that support "Find Remote"
+        "find_remote": "FindRemote",
+        # For Roku TV
+        "volume_down": "VolumeDown",
+        "volume_up": "VolumeUp",
+        "volume_mute": "VolumeMute",
+        # For Roku TV while on TV tuner channel
+        "channel_up": "ChannelUp",
+        "channel_down": "ChannelDown",
+        # For Roku TV current input
+        "input_tuner": "InputTuner",
+        "input_hdmi1": "InputHDMI1",
+        "input_hdmi2": "InputHDMI2",
+        "input_hdmi3": "InputHDMI3",
+        "input_hdmi4": "InputHDMI4",
+        "input_av1": "InputAV1",
+        # For devices that support being turned on/off
+        "power": "Power",
+        "poweroff": "PowerOff",
+        "poweron": "PowerOn",
+    }
+    SENSORS: Final[tuple[str, ...]] = (
+        "acceleration", "magnetic", "orientation", "rotation"
+    )


### PR DESCRIPTION
## Summary
- consolidate project constants into `src/util/constants.py` with scene-based groups
- update modules to import shared constants
- add `--rootdir=.` to `pytest_args` in UI runner

## Testing
- `pytest -q` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689946c94948832bb6c2d34cfeb895cc