### PR TITLE
feat: use shared config loader in performance tests

### DIFF
--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-import os
 import re
 import threading
 import time
@@ -19,10 +18,10 @@ import pytest
 
 from src.tools.router_tool.Router import Router
 from src.tools.router_tool.router_factory import get_router
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
-wifi_yaml = yamlTool(os.getcwd() + '/config/config.yaml')
-router_name = wifi_yaml.get_note('router')['name']
+cfg = load_config()
+router_name = cfg['router']['name']
 # 实例路由器对象
 router = get_router(router_name)
 logging.info(f'router {router}')
@@ -30,7 +29,7 @@ test_data = get_testdata(router)
 
 sum_list_lock = threading.Lock()
 
-rvr_tool = wifi_yaml.get_note('rvr')['tool']
+rvr_tool = cfg['rvr']['tool']
 
 step_list = [0]
 

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-import os
 import re
 import threading
 import time
@@ -21,10 +20,10 @@ import pytest
 from src.tools.connect_tool.lab_device_controller import LabDeviceController
 from src.tools.router_tool.Router import Router
 from src.tools.router_tool.router_factory import get_router
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
-wifi_yaml = yamlTool(os.getcwd() + '/config/config.yaml')
-router_name = wifi_yaml.get_note('router')['name']
+cfg = load_config()
+router_name = cfg['router']['name']
 
 
 # 实例路由器对象
@@ -34,18 +33,18 @@ test_data = get_testdata(router)
 
 sum_list_lock = threading.Lock()
 
-rvr_tool = wifi_yaml.get_note('rvr')['tool']
+rvr_tool = cfg['rvr']['tool']
 
 
 corner_step_list = []
 # 配置衰减
-corner_ip = wifi_yaml.get_note('corner_angle')['ip_address']
+corner_ip = cfg['corner_angle']['ip_address']
 if corner_ip == '192.168.5.11':
-	corner_tool = rs()
+        corner_tool = rs()
 else:
      corner_tool = LabDeviceController(corner_ip)
 logging.info(f'corner_ip {corner_ip}')
-corner_step_list = wifi_yaml.get_note('corner_angle')['step']
+corner_step_list = cfg['corner_angle']['step']
 corner_step_list = [i for i in range(*corner_step_list)][::45]
 logging.info(f'corner step_list {corner_step_list}')
 

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-import os
 import re
 import threading
 import time
@@ -21,10 +20,10 @@ import pytest
 from src.tools.connect_tool.lab_device_controller import LabDeviceController
 from src.tools.router_tool.Router import Router
 from src.tools.router_tool.router_factory import get_router
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
-wifi_yaml = yamlTool(os.getcwd() + '/config/config.yaml')
-router_name = wifi_yaml.get_note('router')['name']
+cfg = load_config()
+router_name = cfg['router']['name']
 
 # 实例路由器对象
 router = get_router(router_name)
@@ -33,23 +32,24 @@ test_data = get_testdata(router)
 
 sum_list_lock = threading.Lock()
 
-rvr_tool = wifi_yaml.get_note('rvr')['tool']
+rvr_tool = cfg['rvr']['tool']
 
 # 初始化 衰减 & 转台 对象
 
 # 读取衰减 配置
 rf_step_list = []
 rf_ip = ''
-model = wifi_yaml.get_note('rf_solution')['model']
+rf_solution = cfg['rf_solution']
+model = rf_solution['model']
 if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'XIN-YI']:
     raise EnvironmentError("Doesn't support this model")
 if model == 'XIN-YI':
     rf_tool = rs()
 else:
-    rf_ip = wifi_yaml.get_note('rf_solution')[model]['ip_address']
+    rf_ip = rf_solution[model]['ip_address']
     rf_tool = LabDeviceController(rf_ip)
     logging.info(f'rf_ip {rf_ip}')
-rf_step_list = wifi_yaml.get_note('rf_solution')['step']
+rf_step_list = rf_solution['step']
 rf_step_list = [i for i in range(*rf_step_list)][::3]
 logging.info(f'rf_step_list {rf_step_list}')
 
@@ -60,7 +60,7 @@ logging.info(f'finally step_list {step_list}')
 # 配置 测试报告
 # pytest.testResult.x_path = [] if (rf_needed and corner_needed) == 'both' else step_list
 rx_result, tx_result = '', ''
-throughput_threshold = float(wifi_yaml.get_note('rvr').get('throughput_threshold', 0))
+throughput_threshold = float(cfg['rvr'].get('throughput_threshold', 0))
 skip_tx = False
 skip_rx = False
 

--- a/src/tools/config_loader.py
+++ b/src/tools/config_loader.py
@@ -1,0 +1,11 @@
+from functools import lru_cache
+from pathlib import Path
+import yaml
+
+
+@lru_cache()
+def load_config():
+    """加载 config.yaml 并缓存结果。"""
+    config_path = Path(__file__).resolve().parents[2] / "config" / "config.yaml"
+    with config_path.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- add config loader with LRU caching for config.yaml
- update WiFi performance tests to pull settings from shared config

## Testing
- `python -m py_compile src/tools/config_loader.py src/test/performance/test_wifi_rvr.py src/test/performance/test_wifi_rvo.py src/test/performance/test_wifi_rvr_rvo.py src/test/performance/test_wifi_peak_throughput.py`
- `pytest src/test/performance/test_wifi_peak_throughput.py::test_rvr -q` *(fails: TypeError: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68999170855c832b93f1266d48c76ebf