### PR TITLE
refactor: centralize config loading

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -20,7 +20,7 @@ from src.tools.connect_tool.adb import adb
 # from tools.connect_tool.host_os import host_os
 from src.tools.connect_tool.telnet_tool import telnet_tool
 from src.tools.TestResult import TestResult
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 from src.dut_control.roku_ctrl import roku_ctrl
 from src.tools.router_tool.Router import Router
 
@@ -52,16 +52,13 @@ def pytest_sessionstart(session):
     else:
         pytest.win_flag = False
     # The configuration information of  DUT
-    if pytest.win_flag:
-        pytest.config_yaml = yamlTool(os.getcwd() + '\\config\\config.yaml')
-    else:
-        pytest.config_yaml = yamlTool(os.getcwd() + '/config/config.yaml')
+    pytest.config = load_config()
     # The connection method to the product to DUT
-    pytest.chip_info = pytest.config_yaml.get_note('fpga')
-    pytest.connect_type = pytest.config_yaml.get_note('connect_type')['type']
+    pytest.chip_info = pytest.config.get('fpga')
+    pytest.connect_type = pytest.config.get('connect_type')['type']
     if pytest.connect_type == 'adb':
         # Create adb obj
-        device = pytest.config_yaml.get_note("connect_type")[pytest.connect_type]['device']
+        device = pytest.config.get("connect_type")[pytest.connect_type]['device']
         if device is None:
             # Obtain the device number dynamically
             info = subprocess.check_output("adb devices", shell=True, encoding='utf-8')
@@ -70,7 +67,7 @@ def pytest_sessionstart(session):
         pytest.dut = adb(serialnumber=device if device else '')
     elif pytest.connect_type == 'telnet':
         # Create telnet obj
-        telnet_ip = pytest.config_yaml.get_note("connect_type")[pytest.connect_type]['ip']
+        telnet_ip = pytest.config.get("connect_type")[pytest.connect_type]['ip']
         pytest.dut = telnet_tool(telnet_ip)
         pytest.dut.roku = roku_ctrl(telnet_ip)
     else:

--- a/src/dut_control/roku_ctrl.py
+++ b/src/dut_control/roku_ctrl.py
@@ -22,13 +22,13 @@ from roku import Roku
 
 from src.tools.connect_tool.serial_tool import serial_tool
 from src.tools.connect_tool.telnet_tool import telnet_tool
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 from src.util.constants import RokuConst
 
 # roku_lux = YamlTool(os.getcwd() + '/config/roku/roku_changhong.yaml')
-roku_config = yamlTool(os.getcwd() + '/config/config.yaml')
-roku_ip = roku_config.get_note("connect_type")['telnet']['ip']
-# roku_ser = roku_config.get_note('dut_serial')
+roku_config = load_config()
+roku_ip = roku_config.get("connect_type")['telnet']['ip']
+# roku_ser = roku_config.get('dut_serial')
 
 lock = threading.Lock()
 

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -3,15 +3,15 @@ import logging
 import os
 
 import pytest
-from pathlib import Path
 from src.tools.router_tool.Router import Router
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 from src.util.constants import get_config_base
+
+config_yaml = load_config()
 
 def get_testdata(router):
     config_base = get_config_base()
-    wifi_yaml = yamlTool(config_base / "config.yaml")
-    router_name = wifi_yaml.get_note('router')['name']
+    router_name = config_yaml.get('router')['name']
     base = config_base / "performance_test_csv"
     if "asus" in router_name:
         csv_path = base / "asus" / "rvr_wifi_setup.csv"

--- a/src/tools/connect_tool/adb.py
+++ b/src/tools/connect_tool/adb.py
@@ -1608,9 +1608,8 @@ class adb(dut):
         return cmd
 
 
-from src.tools.yamlTool import yamlTool
 
-# concomitant_dut_config = yamlTool(os.getcwd() + '/config/config.yaml').get_note('concomitant_dut')
+# concomitant_dut_config = load_config().get('concomitant_dut')
 # if concomitant_dut_config['status']:
 #     accompanying_dut = adb(concomitant_dut_config['device_number'])
 #     accompanying_dut.root()

--- a/src/tools/connect_tool/dut.py
+++ b/src/tools/connect_tool/dut.py
@@ -110,20 +110,20 @@ class dut():
 
     def __init__(self):
         self.serialnumber = 'executer'
-        self.rvr_tool = pytest.config_yaml.get_note('rvr')['tool']
+        self.rvr_tool = pytest.config.get('rvr')['tool']
         self.pair = 5
-        self.repest_times = int(pytest.config_yaml.get_note('rvr')['repeat'])
+        self.repest_times = int(pytest.config.get('rvr')['repeat'])
         self._dut_ip = ''
         self._pc_ip = ''
         self.rvr_result = None
         if self.rvr_tool == 'iperf':
-            self.test_tool = pytest.config_yaml.get_note('rvr')[self.rvr_tool]['version']
-            self.tool_path = pytest.config_yaml.get_note('rvr')[self.rvr_tool]['path'] or ''
+            self.test_tool = pytest.config.get('rvr')[self.rvr_tool]['version']
+            self.tool_path = pytest.config.get('rvr')[self.rvr_tool]['path'] or ''
             logging.info(f'test_tool {self.test_tool}')
 
         if self.rvr_tool == 'ixchariot':
             self.ix = ix()
-            self.test_tool = pytest.config_yaml.get_note('rvr')[self.rvr_tool]
+            self.test_tool = pytest.config.get('rvr')[self.rvr_tool]
             self.script_path = self.test_tool['path']
             logging.info(f'path {self.script_path}')
             logging.info(f'test_tool {self.test_tool}')

--- a/src/tools/connect_tool/host_os.py
+++ b/src/tools/connect_tool/host_os.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import time
 
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
 
 class host_os:
@@ -14,8 +14,8 @@ class host_os:
         return host_os._instance
 
     def __init__(self):
-        self.config = yamlTool(os.getcwd() + '/config/config.yaml')
-        self.host = self.config.get_note('host_os')
+        self.config = load_config()
+        self.host = self.config.get('host_os')
         self.user = self.host['user']
         self.passwd = self.host['password']
         self.ip = ''

--- a/src/tools/connect_tool/lab_device_controller.py
+++ b/src/tools/connect_tool/lab_device_controller.py
@@ -19,7 +19,7 @@ from .telnet_tool import telnet_tool
 class LabDeviceController:
     def __init__(self, ip):
         self.ip = ip
-        self.model = pytest.config_yaml.get_note('rf_solution')['model']
+        self.model = pytest.config.get('rf_solution')['model']
         try:
             logging.info(f'Try to connect {ip}')
             self.tn = telnet_tool(self.ip)

--- a/src/tools/connect_tool/serial_tool.py
+++ b/src/tools/connect_tool/serial_tool.py
@@ -34,8 +34,8 @@ class serial_tool:
     '''
 
     def __init__(self, serial_port='', baud='', log_file="kernel_log.txt", enable_log=True):
-        self.serial_port = serial_port or pytest.config_yaml.get_note('serial_port')['port']
-        self.baud = baud or pytest.config_yaml.get_note('serial_port')['baud']
+        self.serial_port = serial_port or pytest.config.get('serial_port')['port']
+        self.baud = baud or pytest.config.get('serial_port')['baud']
         logging.info(f'port {self.serial_port} baud {self.baud}')
         self.ethernet_ip = ''
         self.uboot_time = 0

--- a/src/tools/mysql_tool/MySqlControl.py
+++ b/src/tools/mysql_tool/MySqlControl.py
@@ -4,15 +4,14 @@
 # @Author  : chao.li
 # @File    : MySqlControl.py
 import logging
-import os
 
 import pymysql
 
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
 try:
-    config= yamlTool(os.getcwd() + '/config/config.yaml')
-    mysql_config = config.get_note('mysql')
+    config = load_config()
+    mysql_config = config.get('mysql')
     my_sqldb_config_param = {
         "host": mysql_config['host'],
         "port": 3306,

--- a/src/tools/pdusnmp.py
+++ b/src/tools/pdusnmp.py
@@ -1,10 +1,9 @@
 # _*_ coding:utf-8 _*_
 # 依赖pysnmp 请自行安装(可以使用命令 pip install pysnmp)
 import logging
-import os
 import subprocess
 
-from src.tools.yamlTool import yamlTool
+from src.tools.config_loader import load_config
 
 
 # global enter_key
@@ -111,8 +110,8 @@ class power_ctrl:
     SET_CMD = 'snmpset -v1 -c private {} 1.3.6.1.4.1.23273.4.4{}.0 i 255'
 
     def __init__(self):
-        self.config = yamlTool(os.path.join(os.getcwd(), 'config/config.yaml'))
-        self.power_ctrl = self.config.get_note('power_relay')
+        self.config = load_config()
+        self.power_ctrl = self.config.get('power_relay')
         self.ip_list = list(self.power_ctrl.keys())
         self.ctrl = self._handle_env_data()
 

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import csv
 from pathlib import Path
 
-import yaml
 import logging
 from contextlib import ExitStack
 from PyQt5.QtCore import Qt, QSignalBlocker
@@ -33,11 +32,11 @@ from qfluentwidgets import (
     InfoBarPosition,
 )
 
-from src.tools.router_tool.router_factory import get_router
-from typing import TYPE_CHECKING
+    from src.tools.router_tool.router_factory import get_router
+    from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from .windows_case_config import CaseConfigPage
+    if TYPE_CHECKING:
+        from .windows_case_config import CaseConfigPage
 
 
 class WifiTableWidget(TableWidget):
@@ -72,7 +71,6 @@ class RvrWifiConfigPage(CardWidget):
         super().__init__()
         self.setObjectName("rvrWifiConfigPage")
         self.case_config_page = case_config_page
-        self.config_path = (Path(Paths.CONFIG_DIR) / "config.yaml").resolve()
         combo = getattr(self.case_config_page, "router_name_combo", None)
         router_name = combo.currentText().lower() if combo is not None else ""
         self.csv_path = self._compute_csv_path(router_name)
@@ -196,9 +194,11 @@ class RvrWifiConfigPage(CardWidget):
         return self.ssid, self.passwd_edit.text()
 
     def _load_router(self, name: str | None = None):
+        from src.tools.config_loader import load_config
+
         try:
-            with open(self.config_path, "r", encoding="utf-8") as f:
-                cfg = yaml.safe_load(f) or {}
+            load_config.cache_clear()
+            cfg = load_config() or {}
             router_name = name or cfg.get("router", {}).get("name", "asusax86u")
             router = get_router(router_name)
         except Exception as e:

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -17,6 +17,7 @@ import logging
 from src.tools.router_tool.router_factory import router_list
 from src.util.constants import Paths
 from src.util.constants import get_config_base
+from src.tools.config_loader import load_config
 from PyQt5.QtCore import (
     Qt,
     QSignalBlocker,
@@ -199,8 +200,8 @@ class CaseConfigPage(CardWidget):
             )
             return {}
         try:
-            with self.config_path.open("r", encoding="utf-8") as f:
-                config = yaml.safe_load(f) or {}
+            load_config.cache_clear()
+            config = load_config() or {}
 
             app_base = self._get_application_base()
             changed = False


### PR DESCRIPTION
## Summary
- refactor power control, MySQL, and various connect tools to use `load_config`
- expose `pytest.config` with shared settings and adjust helpers
- replace direct YAML parsing in UI pages with cached `load_config`

## Testing
- `pytest -q` *(fails: FileNotFoundError: 'pytest.log')*


------
https://chatgpt.com/codex/tasks/task_e_689a9b641ac4832b8d0dd89ebd94a07a