### PR TITLE
feat: 显示配置缓存状态

### DIFF
--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -11,7 +11,7 @@ config_yaml = load_config(refresh=True)
 
 
 def get_testdata(router):
-    config = load_config() or {}
+    config = load_config(refresh=True) or {}
     config_base = get_config_base()
     router_name = config.get('router', {}).get('name', '')
     csv_path = config.get('csv_path')

--- a/src/tools/config_loader.py
+++ b/src/tools/config_loader.py
@@ -16,8 +16,12 @@ def load_config(refresh: bool = False):
 
     默认返回缓存内容；当 ``refresh=True`` 时清除缓存并重新读取文件。
     """
+    config_path = get_config_base() / "config.yaml"
     if refresh:
         load_config.cache_clear()
+        print(f"配置缓存已清理，重新加载: {config_path}")
+    else:
+        print(f"加载配置文件（缓存未清理）: {config_path}")
     return _cached_load_config()
 
 

--- a/src/tools/pdusnmp.py
+++ b/src/tools/pdusnmp.py
@@ -110,7 +110,7 @@ class power_ctrl:
     SET_CMD = 'snmpset -v1 -c private {} 1.3.6.1.4.1.23273.4.4{}.0 i 255'
 
     def __init__(self):
-        self.config = load_config()
+        self.config = load_config(refresh=True)
         self.power_ctrl = self.config.get('power_relay')
         self.ip_list = list(self.power_ctrl.keys())
         self.ctrl = self._handle_env_data()


### PR DESCRIPTION
## Summary
- 加入配置加载日志，打印缓存状态与文件路径
- 在 `pdusnmp` 与测试工具中使用 `load_config(refresh=True)` 强制刷新

## Testing
- `pytest -q` *(中断: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689c86f3dc50832b815a9ae0359836a8