### PR TITLE
在 RVR 性能测试中动态加载路由器配置

### DIFF
--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -22,11 +22,7 @@ from src.tools.router_tool.Router import Router
 from src.tools.router_tool.router_factory import get_router
 from src.tools.config_loader import load_config
 
-router_name = load_config(refresh=True)['router']['name']
-# 实例路由器对象
-router = get_router(router_name)
-logging.info(f'router {router}')
-test_data = get_testdata(router)
+test_data = get_testdata(get_router(load_config(refresh=True)['router']['name']))
 
 sum_list_lock = threading.Lock()
 
@@ -47,6 +43,9 @@ def setup(request):
     skip_rx = False
     logging.info('router setup start')
     cfg = load_config(refresh=True)
+    router_name = cfg['router']['name']
+    router = get_router(router_name)
+    logging.info(f'router {router}')
     rf_solution = cfg['rf_solution']
     print(f"rf_solution['step']: {rf_solution['step']}")
     model = rf_solution['model']


### PR DESCRIPTION
## Summary
- 动态获取测试数据所需的路由器实例，移除模块级别的固定配置
- 在 setup fixture 中重新加载配置并实例化路由器，确保每次运行使用最新配置

## Testing
- `python -m py_compile src/test/performance/test_wifi_rvr.py`
- `pytest --collect-only src/test/performance/test_wifi_rvr.py` *(fail: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_689c9620b714832ba2bc0d710e0e9528