### PR TITLE
refactor: replace prints with logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,11 @@ from src.util.constants import Paths, cleanup_temp_dir
 os.chdir(Paths.BASE_DIR)
 
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+
 def log_exception(exc_type, exc_value, exc_tb):
     logging.error("".join(traceback.format_exception(exc_type, exc_value, exc_tb)))
 
@@ -107,7 +112,7 @@ class MainWindow(FluentWindow):
             self._remove_interface(self.run_page)
             self.run_page = None
             self._run_nav_button = None
-            print("RunPage cleared!")
+            logging.info("RunPage cleared")
 
     def _set_nav_buttons_enabled(self, enabled: bool):
         """启用或禁用除 RunPage 外的导航按钮"""
@@ -140,9 +145,9 @@ class MainWindow(FluentWindow):
                 if hasattr(self.rvr_wifi_config_page, "set_router_credentials"):
                     self.rvr_wifi_config_page.set_router_credentials(ssid or "", passwd or "")
             self.stackedWidget.setCurrentWidget(page_widget)
-            print(f"FluentWindow.setCurrentWidget({page_widget}) success")
+            logging.debug("Switched widget to %s", page_widget)
         except Exception as e:
-            print(f"FluentWindow.setCurrentWidget error: {e}")
+            logging.error("Failed to set current widget: %s", e)
 
     def on_run(self, case_path, display_case_path, config):
         self.clear_run_page()
@@ -176,17 +181,17 @@ class MainWindow(FluentWindow):
         runner = getattr(self.run_page, "runner", None)
         if runner:
             runner.finished.connect(lambda: self._set_nav_buttons_enabled(True))
-        print("Switched to RunPage:", self.run_page)
+        logging.info("Switched to RunPage: %s", self.run_page)
 
     def show_case_config(self):
         self.setCurrentIndex(self.case_config_page)
-        print("Switched to CaseConfigPage")
+        logging.info("Switched to CaseConfigPage")
 
     def stop_run_and_show_case_config(self):
         self.setCurrentIndex(self.case_config_page)
         QCoreApplication.processEvents()  # 强制事件刷新
         self._set_nav_buttons_enabled(True)
-        print("Switched to CaseConfigPage")
+        logging.info("Switched to CaseConfigPage")
 
 
 sys.excepthook = log_exception

--- a/src/tools/config_loader.py
+++ b/src/tools/config_loader.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from src.util.constants import get_config_base
 import yaml
+import logging
 
 
 @lru_cache()
@@ -19,23 +20,23 @@ def load_config(refresh: bool = False):
     config_path = get_config_base() / "config.yaml"
     if refresh:
         load_config.cache_clear()
-        print(f"配置缓存已清理，重新加载: {config_path}")
+        logging.info("Cache cleared, reloading %s", config_path)
     else:
-        print(f"加载配置文件（缓存未清理）: {config_path}")
+        logging.debug("Loading config file without clearing cache: %s", config_path)
 
     config = _cached_load_config()
 
     if refresh:
         try:
-            print(f"config_path: {config_path}")
-            print(f"rf_solution['step']: {config['rf_solution']['step']}")
+            logging.debug("config_path: %s", config_path)
+            logging.debug("rf_solution['step']: %s", config['rf_solution']['step'])
         except Exception as e:
-            print(f"无法获取 rf_solution['step']: {e}")
+            logging.warning("Failed to get rf_solution['step']: %s", e)
         try:
             with open(config_path, encoding="utf-8") as f:
-                print(f"配置文件内容:\n{f.read()}")
+                logging.debug("Config file content:\n%s", f.read())
         except Exception as e:
-            print(f"无法读取配置文件内容: {e}")
+            logging.warning("Failed to read config file content: %s", e)
 
     return config
 

--- a/src/tools/router_tool/AsusRouter/Asusax88uControl.py
+++ b/src/tools/router_tool/AsusRouter/Asusax88uControl.py
@@ -125,8 +125,7 @@ class Asusax88uControl(RouterTools):
 
     def telnet_write(self, cmd, max_retries=3):
         """使用已建立的Telnet连接执行命令（修复：复用连接）"""
-        logging.info(f"Executing command: {cmd}")
-        print(f"Executing command: {cmd}")
+        logging.info("Executing command: %s", cmd)
         retries = 0
         while retries < max_retries:
             try:
@@ -150,15 +149,15 @@ class Asusax88uControl(RouterTools):
         try:
             # 终止所有Telnet服务进程（包括残留连接）
             output = self.telnet_write("killall telnetd\n")
-            logging.info(f"终止Telnet进程输出: {output}")
-            time.sleep(2)  # 等待进程终止
+            logging.info("Terminate telnetd output: %s", output)
+            time.sleep(2)  # wait for process to end
 
-            # 重新启动Telnet服务
+            # restart telnet service
             output = self.telnet_write("telnetd\n")
-            logging.info(f"重启Telnet服务输出: {output}")
-            print("Telnet连接已释放，端口23可用")
+            logging.info("Restart telnetd output: %s", output)
+            logging.info("Telnet connection released, port 23 available")
         except Exception as e:
-            print(f"执行命令失败（可能已无法建立连接）: {e}")
+            logging.error("Failed to execute command, connection may be closed: %s", e)
 
     def quit(self):
         try:

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -222,19 +222,19 @@ class RvrWifiConfigPage(CardWidget):
         ]
         headers = default_headers
         rows: list[dict[str, str]] = []
-        print(f"_load_csv path={self.csv_path}")
+        logging.debug("Loading CSV from %s", self.csv_path)
         if self.csv_path.exists():
             with open(self.csv_path, newline="", encoding="utf-8") as f:
                 reader = csv.DictReader(f)
                 headers = reader.fieldnames or default_headers
                 for row in reader:
                     rows.append({h: row.get(h, "") for h in headers})
-        print(f"_load_csv headers={headers} rows={len(rows)}")
+        logging.debug("Loaded headers %s with %d rows", headers, len(rows))
         return headers, rows
 
     def reload_csv(self):
         """重新读取当前 CSV 并刷新表格"""
-        print(f"reload_csv using {self.csv_path}")
+        logging.info("Reloading CSV from %s", self.csv_path)
         self.headers, self.rows = self._load_csv()
         self.refresh_table()
 
@@ -278,9 +278,9 @@ class RvrWifiConfigPage(CardWidget):
         if not path:
             return
         # 确保使用绝对路径加载 CSV，避免目录切换引起的混淆
-        print(f"on_csv_file_changed path={path}")
+        logging.debug("CSV file changed: %s", path)
         self.csv_path = Path(path).resolve()
-        print(f"resolved csv_path={self.csv_path}")
+        logging.debug("Resolved CSV path: %s", self.csv_path)
 
         self.reload_csv()
         self._loading = True

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -162,9 +162,9 @@ class CaseConfigPage(CardWidget):
         判断 abs_case_path 是否位于 test/performance 目录（任何层级都算）。
         不依赖工程根路径，只看路径片段。
         """
-        print(f"_is_performance_case path={abs_case_path}")
+        logging.debug("Checking performance case path: %s", abs_case_path)
         if not abs_case_path:
-            print("_is_performance_case: empty path -> False")
+            logging.debug("_is_performance_case: empty path -> False")
             return False
         try:
             from pathlib import Path
@@ -172,12 +172,12 @@ class CaseConfigPage(CardWidget):
             # 检查父链中是否出现 .../test/performance
             for node in (p, *p.parents):
                 if node.name == "performance" and node.parent.name == "test":
-                    print("_is_performance_case: True")
+                    logging.debug("_is_performance_case: True")
                     return True
-                print("_is_performance_case: False")
+                logging.debug("_is_performance_case: False")
             return False
         except Exception as e:
-            print(f"_is_performance_case exception: {e}")
+            logging.error("_is_performance_case exception: %s", e)
             return False
 
     def _init_case_tree(self, root_dir: Path) -> None:
@@ -268,11 +268,11 @@ class CaseConfigPage(CardWidget):
             return {}
 
     def _save_config(self):
-        print(f"[save] path={self.config_path} data={self.config}")
+        logging.debug("[save] path=%s data=%s", self.config_path, self.config)
         try:
             with self.config_path.open("w", encoding="utf-8") as f:
                 yaml.safe_dump(self.config, f, allow_unicode=True, sort_keys=False, width=4096)
-                print("[save] config saved")
+                logging.info("Configuration saved")
             self.config = self._load_config()
             QTimer.singleShot(
                 0,
@@ -284,7 +284,7 @@ class CaseConfigPage(CardWidget):
                 ),
             )
         except Exception as exc:
-            print(f"[save] failed: {exc}")
+            logging.error("[save] failed: %s", exc)
             QTimer.singleShot(
                 0,
                 lambda exc=exc: InfoBar.error(
@@ -368,13 +368,12 @@ class CaseConfigPage(CardWidget):
             csv_dir = base_dir / "xiaomi"
         else:
             csv_dir = None
-        logging.debug("_update_csv_options %s", csv_dir)
-        print(f"_update_csv_options router={router_name} dir={csv_dir}")
+        logging.debug("_update_csv_options router=%s dir=%s", router_name, csv_dir)
         with QSignalBlocker(self.csv_combo):
             self.csv_combo.clear()
             if csv_dir and csv_dir.exists():
                 for csv_file in sorted(csv_dir.glob("*.csv")):
-                    print(f"found csv: {csv_file}")
+                    logging.debug("found csv: %s", csv_file)
                     # qfluentwidgets.ComboBox 在 Qt5 和 Qt6 下对 userData 的处理不一致，
                     # 直接通过 addItem(text, userData) 可能导致无法获取到数据。
                     # 因此先添加文本，再显式设置 UserRole 数据，确保 itemData 能正确返回文件路径。
@@ -755,8 +754,8 @@ class CaseConfigPage(CardWidget):
             display_path = os.path.relpath(path, base)
         except ValueError:
             display_path = path
-        print(f"on_case_tree_clicked path={path} display={display_path}")
-        print(f"on_case_tree_clicked is_performance={self._is_performance_case(path)}")
+        logging.debug("on_case_tree_clicked path=%s display=%s", path, display_path)
+        logging.debug("on_case_tree_clicked is_performance=%s", self._is_performance_case(path))
         # ---------- 目录：只负责展开/折叠 ----------
         if os.path.isdir(path):
             if self.case_tree.isExpanded(proxy_idx):
@@ -786,7 +785,7 @@ class CaseConfigPage(CardWidget):
         """根据用例名与路径返回可编辑字段以及相关 UI 使能状态"""
         basename = os.path.basename(case_path)
         logging.debug("testcase name %s", basename)
-        print(f"_compute_editable_info case_path={case_path} basename={basename}")
+        logging.debug("_compute_editable_info case_path=%s basename=%s", case_path, basename)
         rvr_keys = {
             "rvr",
             "rvr.tool",
@@ -842,23 +841,24 @@ class CaseConfigPage(CardWidget):
         base = Path(self._get_application_base())
         perf_dir = (base / "test" / "performance").resolve()
         case_abs = Path(case_path).resolve() if case_path else None
-        print(f"_compute_editable_info perf_dir={perf_dir} case_abs={case_abs}")
+        logging.debug("_compute_editable_info perf_dir=%s case_abs=%s", perf_dir, case_abs)
         if case_abs and perf_dir in case_abs.parents:
             info.enable_csv = True
             info.enable_rvr_wifi = True
-        print(
-            f"_compute_editable_info enable_csv={info.enable_csv} "
-            f"enable_rvr_wifi={info.enable_rvr_wifi}"
+        logging.debug(
+            "_compute_editable_info enable_csv=%s enable_rvr_wifi=%s",
+            info.enable_csv,
+            info.enable_rvr_wifi,
         )
         # 如果你需要所有字段都可编辑，直接 return EditableInfo(set(self.field_widgets.keys()), True, True)
         return info
 
     def get_editable_fields(self, case_path) -> EditableInfo:
         """选中用例后控制字段可编辑性并返回相关信息"""
-        print(f"get_editable_fields case_path={case_path}")
+        logging.debug("get_editable_fields case_path=%s", case_path)
         if self._refreshing:
             # 极少见：递归进入，直接丢弃
-            print("get_editable_fields: refreshing, return empty")
+            logging.debug("get_editable_fields: refreshing, return empty")
             return EditableInfo()
 
         # ---------- 进入刷新 ----------
@@ -868,7 +868,7 @@ class CaseConfigPage(CardWidget):
 
         try:
             info = self._compute_editable_info(case_path)
-            print(f"get_editable_fields enable_csv={info.enable_csv}")
+            logging.debug("get_editable_fields enable_csv=%s", info.enable_csv)
             # 若 csv 下拉框尚未创建，则视为不支持 CSV 功能
             if info.enable_csv and not hasattr(self, "csv_combo"):
                 info.enable_csv = False
@@ -907,7 +907,7 @@ class CaseConfigPage(CardWidget):
                 self.selected_csv_path = None
         else:
             self.selected_csv_path = None
-            print("csv_combo disabled")
+            logging.debug("csv_combo disabled")
         # 若用户在刷新过程中又点了别的用例，延迟 0 ms 处理它
         if self._pending_path:
             path = self._pending_path
@@ -934,7 +934,7 @@ class CaseConfigPage(CardWidget):
 
     def on_csv_activated(self, index: int) -> None:
         """用户手动点击同一项时也需要重新加载"""
-        print(f"on_csv_activated index={index}")
+        logging.debug("on_csv_activated index=%s", index)
         self.on_csv_changed(index, force=True)
 
     def on_csv_changed(self, index: int, force: bool = False) -> None:
@@ -944,18 +944,20 @@ class CaseConfigPage(CardWidget):
             return
         # 明确使用 UserRole 获取数据，避免在不同 Qt 版本下默认角色不一致
         data = self.csv_combo.itemData(index)
-        print(f"on_csv_changed index={index} data={data}")
+        logging.debug("on_csv_changed index=%s data=%s", index, data)
         new_path = str(Path(data).resolve()) if data else None
         if not force and new_path == self.selected_csv_path:
             return
         self.selected_csv_path = new_path
-        print(f"selected_csv_path={self.selected_csv_path}")
+        logging.debug("selected_csv_path=%s", self.selected_csv_path)
         self.csvFileChanged.emit(self.selected_csv_path or "")
 
     def on_run(self):
-        print(
-            f"[on_run] start case={self.field_widgets['text_case'].text().strip()} "
-            f"csv={self.selected_csv_path} config={self.config}"
+        logging.info(
+            "[on_run] start case=%s csv=%s config=%s",
+            self.field_widgets['text_case'].text().strip(),
+            self.selected_csv_path,
+            self.config,
         )
         # 将字段值更新到 self.config（保持结构）
         for key, widget in self.field_widgets.items():
@@ -995,7 +997,7 @@ class CaseConfigPage(CardWidget):
         abs_case_path = (
             (base / case_path).resolve().as_posix() if case_path else ""
         )
-        print(f"[on_run] before performance check abs_case_path={abs_case_path} csv={self.selected_csv_path}")
+        logging.debug("[on_run] before performance check abs_case_path=%s csv=%s", abs_case_path, self.selected_csv_path)
         # 先将当前用例路径及 CSV 选择写入配置
         self.config["text_case"] = case_path
         if self.selected_csv_path:
@@ -1007,7 +1009,7 @@ class CaseConfigPage(CardWidget):
             self.config["csv_path"] = Path(rel_csv).as_posix()
         else:
             self.config.pop("csv_path", None)
-        print(f"[on_run] after performance check abs_case_path={abs_case_path} csv={self.selected_csv_path}")
+        logging.debug("[on_run] after performance check abs_case_path=%s csv=%s", abs_case_path, self.selected_csv_path)
         # 若树状视图中选择了有效用例，则覆盖默认路径
         proxy_idx = self.case_tree.currentIndex()
         model = self.case_tree.model()
@@ -1026,9 +1028,9 @@ class CaseConfigPage(CardWidget):
             # 更新配置中的用例路径
         self.config["text_case"] = case_path
         # 保存配置
-        print("[on_run] before _save_config")
+        logging.debug("[on_run] before _save_config")
         self._save_config()
-        print("[on_run] after _save_config")
+        logging.debug("[on_run] after _save_config")
         try:
             if self._is_performance_case(abs_case_path) and not getattr(self, "selected_csv_path", None):
                 try:


### PR DESCRIPTION
## Summary
- centralize output via the logging module and translate messages to English
- switch UI configuration modules to use debug/info logs instead of print statements
- log networking utilities actions instead of printing to stdout

## Testing
- `pytest` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d6418c8832b810fe7db1ab82379