### PR TITLE
refactor: consolidate throughput skip logic

### DIFF
--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -34,12 +34,13 @@ logging.info(f'finally step_list {step_list}')
 
 # 配置 测试报告
 # pytest.testResult.x_path = [] if (rf_needed and corner_needed) == 'both' else step_list
-rx_result, tx_result = '', ''
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup(request):
-    global rx_result, tx_result, pc_ip, dut_ip
+    global pc_ip, dut_ip
+    pytest.dut.skip_tx = False
+    pytest.dut.skip_rx = False
     logging.info('router setup start')
     cfg = load_config(refresh=True)
     rvr_tool = cfg['rvr']['tool']
@@ -110,7 +111,6 @@ def setup(request):
 # 测试 iperf
 @pytest.mark.parametrize("rf_value", step_list)
 def test_rvr(setup, rf_value):
-    global rx_result, tx_result
     # 判断板子是否存在  ip
     if not setup[0]:
         logging.info("Can't connect wifi ,input 0")

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -36,12 +36,13 @@ corner_tool = None
 
 # 配置 测试报告
 # pytest.testResult.x_path = [] if (rf_needed and corner_needed) == 'both' else step_list
-rx_result, tx_result = '', ''
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup(request):
-        global rx_result, tx_result, pc_ip, dut_ip, corner_tool
+        global pc_ip, dut_ip, corner_tool
+        pytest.dut.skip_tx = False
+        pytest.dut.skip_rx = False
         cfg = load_config(refresh=True)
         rvr_tool = cfg['rvr']['tool']
         logging.info('router setup start')
@@ -144,7 +145,6 @@ def setup(request):
 
 # 测试 iperf
 def test_rvr(setup):
-        global rx_result, tx_result
         connect_status, router_info, corner_step_list = setup
         if not connect_status:
                 logging.info("Can't connect wifi ,input 0")
@@ -173,11 +173,11 @@ def test_rvr(setup):
                 logging.info(f'router_info: {router_info}')
                 if 'tx' in router_info.test_type:
                         logging.info(f'rssi : {rssi_num} ')
-                        pytest.dut.get_tx_rate(router_info, rssi_num, 'TCP',
+                        pytest.dut.get_tx_rate(router_info, 'TCP',
                                                corner_tool=corner_tool,
                                                db_set=db_set)
                 if 'rx' in router_info.test_type:
                         logging.info(f'rssi : {rssi_num}')
-                        pytest.dut.get_rx_rate(router_info, rssi_num, 'TCP',
+                        pytest.dut.get_rx_rate(router_info, 'TCP',
                                                corner_tool=corner_tool,
                                                db_set=db_set)

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -31,16 +31,13 @@ rf_tool = None
 
 # 配置 测试报告
 # pytest.testResult.x_path = [] if (rf_needed and corner_needed) == 'both' else step_list
-rx_result, tx_result = '', ''
-skip_tx = False
-skip_rx = False
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup(request):
-    global rx_result, tx_result, skip_rx, skip_tx, rf_tool
-    skip_tx = False
-    skip_rx = False
+    global rf_tool
+    pytest.dut.skip_tx = False
+    pytest.dut.skip_rx = False
     logging.info('router setup start')
     cfg = load_config(refresh=True)
     router_name = cfg['router']['name']
@@ -132,11 +129,7 @@ def setup(request):
 
 # 测试 iperf
 def test_rvr(setup):
-    global rx_result, tx_result, skip_tx, skip_rx
-    cfg = load_config(refresh=True)
-    throughput_threshold = float(cfg['rvr'].get('throughput_threshold', 0))
     connect_status, router_info, rf_step_list = setup
-    # 判断板子是否存在  ip
     if not connect_status:
         logging.info("Can't connect wifi ,input 0")
         with open(pytest.testResult.detail_file, 'a') as f:
@@ -155,42 +148,11 @@ def test_rvr(setup):
             f.write(info)
 
         pytest.dut.get_rssi()
-        if skip_tx:
-            tx_result_info = (
-                f'{pytest.dut.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
-                f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} UL NULL NULL {db_set} {pytest.dut.rssi_num} NULL NULL '
-                f'"NULL" {",".join(map(str, [0]))}')
-            logging.info(tx_result_info)
-            pytest.testResult.save_result(tx_result_info.replace(' ', ','))
-        if skip_rx:
-            rx_result_info = (
-                f'{pytest.dut.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
-                f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} DL NULL NULL {db_set} {pytest.dut.rssi_num} NULL NULL '
-                f'"NULL" {",".join(map(str, [0]))}')
-            pytest.testResult.save_result(rx_result_info.replace(' ', ','))
-        if skip_tx and skip_rx:
-            continue
-        # handle iperf pair count
         logging.info('start test iperf')
         logging.info(f'router_info: {router_info}')
-        # iperf  打流
-        # if router_info.rx and not skip_tx:
-        #     logging.info(f'rssi : {pytest.dut.rssi_num}')
-        #     tx_result = pytest.dut.get_tx_rate(router_info, 'TCP', db_set=db_set)
-        #     try:
-        #         tx_val = float(tx_result.split(',')[0])
-        #     except Exception:
-        #         tx_val = 0
-        #     if tx_val < throughput_threshold:
-        #         skip_tx = True
-        # if router_info.tx and not skip_rx:
-        #     logging.info(f'rssi : {pytest.dut.rssi_num}')
-        #     rx_result = pytest.dut.get_rx_rate(router_info, 'TCP', db_set=db_set)
-        #     try:
-        #         rx_val = float(rx_result.split(',')[0])
-        #     except Exception:
-        #         rx_val = 0
-        #     if rx_val < throughput_threshold:
-        #         skip_rx = True
+        if router_info.rx:
+            logging.info(f'rssi : {pytest.dut.rssi_num}')
+            pytest.dut.get_tx_rate(router_info, 'TCP', db_set=db_set)
+        if router_info.tx:
+            logging.info(f'rssi : {pytest.dut.rssi_num}')
+            pytest.dut.get_rx_rate(router_info, 'TCP', db_set=db_set)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -37,16 +37,13 @@ corner_tool = None
 
 # 配置 测试报告
 # pytest.testResult.x_path = [] if (rf_needed and corner_needed) == 'both' else step_list
-rx_result, tx_result = '', ''
-skip_tx = False
-skip_rx = False
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup(request):
-    global rx_result, tx_result, pc_ip, dut_ip, skip_tx, skip_rx, rf_tool, corner_tool
-    skip_tx = False
-    skip_rx = False
+    global pc_ip, dut_ip, rf_tool, corner_tool
+    pytest.dut.skip_tx = False
+    pytest.dut.skip_rx = False
     logging.info('router setup start')
     cfg = load_config(refresh=True)
     rvr_tool = cfg['rvr']['tool']
@@ -161,9 +158,6 @@ def setup(request):
 
 # 测试 iperf
 def test_rvr(setup):
-    global rx_result, tx_result, skip_tx, skip_rx
-    cfg = load_config(refresh=True)
-    throughput_threshold = float(cfg['rvr'].get('throughput_threshold', 0))
     connect_status, router_info, step_list = setup
     if not connect_status:
         logging.info("Can't connect wifi ,input 0")
@@ -190,40 +184,11 @@ def test_rvr(setup):
             f.write(info)
 
         pytest.dut.get_rssi()
-        if skip_tx:
-            tx_result_info = (
-                f'{pytest.dut.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
-                f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} UL NULL NULL {db_set} {pytest.dut.rssi_num} NULL NULL '
-                f'"NULL" {",".join(map(str, [0]))}')
-            logging.info(tx_result_info)
-            pytest.testResult.save_result(tx_result_info.replace(' ', ','))
-        if skip_rx:
-            rx_result_info = (
-                f'{pytest.dut.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
-                f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} DL NULL NULL {db_set} {pytest.dut.rssi_num} NULL NULL '
-                f'"NULL" {",".join(map(str, [0]))}')
-            pytest.testResult.save_result(rx_result_info.replace(' ', ','))
-        if skip_tx and skip_rx:
-            return
         logging.info('start test iperf')
         logging.info(f'router_info: {router_info}')
-        if router_info.tx and not skip_tx:
+        if router_info.tx:
             logging.info(f'rssi : {pytest.dut.rssi_num}')
-            tx_result = pytest.dut.get_tx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
-            try:
-                tx_val = float(tx_result.split(',')[0])
-            except Exception:
-                tx_val = 0
-            if tx_val < throughput_threshold:
-                skip_tx = True
-        if router_info.rx and not skip_rx:
+            pytest.dut.get_tx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
+        if router_info.rx:
             logging.info(f'rssi : {pytest.dut.rssi_num}')
-            rx_result = pytest.dut.get_rx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
-            try:
-                rx_val = float(rx_result.split(',')[0])
-            except Exception:
-                rx_val = 0
-            if rx_val < throughput_threshold:
-                skip_rx = True
+            pytest.dut.get_rx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)


### PR DESCRIPTION
## Summary
- move throughput skip handling into DUT `get_tx_rate`/`get_rx_rate`
- simplify performance tests to delegate skip decisions to DUT

## Testing
- `pytest src/test/performance/test_wifi_peak_throughput.py::test_rvr -q` *(fails: No module named 'yaml')*
- `pip install pyyaml` *(fails: Cannot connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_689d8860e190832b927e4aecc00e433f