### PR TITLE
feat: support fpga selection and expected rate logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from contextlib import suppress
 
 sys.path.insert(0, str(Path(__file__).parent))
 from PyQt5.QtWidgets import QApplication, QAbstractButton
+import sip
 from qfluentwidgets import FluentIcon, FluentWindow, NavigationItemPosition
 from src.ui.windows_case_config import CaseConfigPage
 from src.ui.rvr_wifi_config import RvrWifiConfigPage
@@ -64,6 +65,9 @@ class MainWindow(FluentWindow):
 
     def show_rvr_wifi_config(self):
         """在导航栏中显示 RVR Wi-Fi 配置页"""
+        # 页面可能已被删除，需重新实例化
+        if self.rvr_wifi_config_page is None or sip.isdeleted(self.rvr_wifi_config_page):
+            self.rvr_wifi_config_page = RvrWifiConfigPage(self.case_config_page)
         if hasattr(self.rvr_wifi_config_page, "reload_csv"):
             self.rvr_wifi_config_page.reload_csv()
         if self.stackedWidget.indexOf(self.rvr_wifi_config_page) == -1:
@@ -76,7 +80,9 @@ class MainWindow(FluentWindow):
 
     def hide_rvr_wifi_config(self):
         """从导航栏移除 RVR Wi-Fi 配置页"""
-        self._remove_interface(self.rvr_wifi_config_page)
+        if self.rvr_wifi_config_page and not sip.isdeleted(self.rvr_wifi_config_page):
+            self._remove_interface(self.rvr_wifi_config_page)
+        self.rvr_wifi_config_page = None
 
     def removeSubInterface(self, page):
         """Remove the given page from the navigation if possible."""

--- a/src/tools/TestResult.py
+++ b/src/tools/TestResult.py
@@ -46,7 +46,7 @@ class TestResult():
             self.log_file = os.path.join(self.logdir,
                                          'Rvr' + time.asctime().replace(' ', '_').replace(':', '_') + '.csv')
             with open(self.log_file, 'a', encoding='utf-8') as f:
-                title = 'SerianNumber Test_Category	Sub_Category	Coex_Method	BT_WF_Isolation	Standard	Freq_Band	BW	Data_Rate	CH_Freq_MHz	Protocol	Direction	Total_Path_Loss	RxP DB	RSSI Angel	Data_RSSI MCS_Rate Throughput	'
+                title = 'SerianNumber Test_Category	Sub_Category	Coex_Method	BT_WF_Isolation	Standard	Freq_Band	BW	Data_Rate	CH_Freq_MHz	Protocol	Direction	Total_Path_Loss	RxP DB	RSSI Angel	Data_RSSI MCS_Rate Throughput Expect_Rate '
                 f.write(','.join(title.split()))
                 f.write('\n')
         if not hasattr(self, 'detail_file'):

--- a/src/tools/connect_tool/dut.py
+++ b/src/tools/connect_tool/dut.py
@@ -21,6 +21,7 @@ import telnetlib
 from src.tools.ixchariot import ix
 from threading import Thread
 from src.tools.config_loader import load_config
+from src.tools.router_tool.router_performance import handle_expectdata
 
 lock = threading.Lock()
 
@@ -350,12 +351,20 @@ class dut():
 
     @step
     def get_rx_rate(self, router_info, type='TCP', corner_tool=None, db_set=''):
+        router_cfg = {
+            router_info.band: {
+                'mode': router_info.wireless_mode,
+                'authentication': router_info.authentication,
+                'bandwidth': router_info.bandwidth,
+            }
+        }
+        expect_rate = handle_expectdata(router_cfg, router_info.band, 'DL', pytest.chip_info)
         if self.skip_rx:
             corner = corner_tool.get_turntanle_current_angle() if corner_tool else ''
             rx_result_info = (
                 f'{self.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
                 f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} DL NULL NULL {db_set} {self.rssi_num} {corner} NULL "NULL" 0')
+                f'{router_info.channel} {type} DL NULL NULL {db_set} {self.rssi_num} {corner} NULL "NULL" 0 {expect_rate}')
             pytest.testResult.save_result(rx_result_info.replace(' ', ','))
             with open(pytest.testResult.detail_file, 'a', encoding='utf-8') as f:
                 f.write(f'Rx {type} result : 0\n')
@@ -424,7 +433,7 @@ class dut():
             f'{self.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
             f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
             f'{router_info.channel} {type} DL NULL NULL {db_set} {self.rssi_num} {corner} NULL '
-            f'{mcs_rx if mcs_rx else "NULL"} {",".join(map(str, rx_result_list))}')
+            f'{mcs_rx if mcs_rx else "NULL"} {",".join(map(str, rx_result_list))} {expect_rate}')
         pytest.testResult.save_result(rx_result_info.replace(' ', ','))
         with open(pytest.testResult.detail_file, 'a', encoding='utf-8') as f:
             logging.info('writing')
@@ -434,12 +443,20 @@ class dut():
 
     @step
     def get_tx_rate(self, router_info, type='TCP', corner_tool=None, db_set=''):
+        router_cfg = {
+            router_info.band: {
+                'mode': router_info.wireless_mode,
+                'authentication': router_info.authentication,
+                'bandwidth': router_info.bandwidth,
+            }
+        }
+        expect_rate = handle_expectdata(router_cfg, router_info.band, 'UL', pytest.chip_info)
         if self.skip_tx:
             corner = corner_tool.get_turntanle_current_angle() if corner_tool else ''
             tx_result_info = (
                 f'{self.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
                 f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
-                f'{router_info.channel} {type} UL NULL NULL {db_set} {self.rssi_num} {corner} NULL "NULL" 0')
+                f'{router_info.channel} {type} UL NULL NULL {db_set} {self.rssi_num} {corner} NULL "NULL" 0 {expect_rate}')
             logging.info(tx_result_info)
             pytest.testResult.save_result(tx_result_info.replace(' ', ','))
             with open(pytest.testResult.detail_file, 'a') as f:
@@ -512,7 +529,7 @@ class dut():
             f'{self.serialnumber} Throughput Standalone NULL Null {router_info.wireless_mode.split()[0]} '
             f'{router_info.band.split()[0]} {router_info.bandwidth.split()[0]} Rate_Adaptation '
             f'{router_info.channel} {type} UL NULL NULL {db_set} {self.rssi_num} {corner} NULL '
-            f'{mcs_tx if mcs_tx else "NULL"} {",".join(map(str, tx_result_list))}')
+            f'{mcs_tx if mcs_tx else "NULL"} {",".join(map(str, tx_result_list))} {expect_rate}')
         logging.info(tx_result_info)
         pytest.testResult.save_result(tx_result_info.replace(' ', ','))
         with open(pytest.testResult.detail_file, 'a') as f:

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -16,7 +16,7 @@ import yaml
 import logging
 from dataclasses import dataclass, field
 from src.tools.router_tool.router_factory import router_list
-from src.util.constants import Paths
+from src.util.constants import Paths, RouterConst
 from src.util.constants import get_config_base, get_src_base
 from src.tools.config_loader import load_config
 from PyQt5.QtCore import (
@@ -451,6 +451,27 @@ class CaseConfigPage(CardWidget):
                 self.field_widgets["connect_type.type"] = self.connect_type_combo
                 self.field_widgets["connect_type.adb.device"] = self.adb_device_edit
                 self.field_widgets["connect_type.telnet.ip"] = self.telnet_ip_edit
+                continue
+            if key == "fpga":
+                group = QGroupBox("FPGA")
+                vbox = QVBoxLayout(group)
+                self.fpga_chip_combo = ComboBox(self)
+                self.fpga_chip_combo.addItems(RouterConst.FPGA_CONFIG.keys())
+                self.fpga_if_combo = ComboBox(self)
+                self.fpga_if_combo.addItems(RouterConst.INTERFACE_CONFIG)
+                chip_default, if_default = "W2", "SDIO"
+                if isinstance(value, str) and "_" in value:
+                    chip_default, if_default = value.split("_", 1)
+                    chip_default = chip_default.upper()
+                    if_default = if_default.upper()
+                self.fpga_chip_combo.setCurrentText(chip_default)
+                self.fpga_if_combo.setCurrentText(if_default)
+                vbox.addWidget(QLabel("Chip:"))
+                vbox.addWidget(self.fpga_chip_combo)
+                vbox.addWidget(QLabel("Interface:"))
+                vbox.addWidget(self.fpga_if_combo)
+                self._add_group(group)
+                self.field_widgets["fpga"] = group
                 continue
             if key == "rf_solution":
                 group = QGroupBox("RF Solution")
@@ -990,6 +1011,9 @@ class CaseConfigPage(CardWidget):
                 ref[leaf] = True if text == 'True' else False if text == 'False' else text
             elif isinstance(widget, QCheckBox):
                 ref[leaf] = widget.isChecked()
+        chip = self.fpga_chip_combo.currentText()
+        interface = self.fpga_if_combo.currentText()
+        self.config["fpga"] = f"{chip.lower()}_{interface.lower()}"
         base = Path(self._get_application_base())
         case_path = self.field_widgets["text_case"].text().strip()
         # 默认将现有路径解析成 POSIX 字符串


### PR DESCRIPTION
## Summary
- split FPGA setting into chip and interface selectors and persist choice to config
- expose expected throughput from router_performance and record Expect_Rate in results
- reuse router_performance expected data lookup in compatibility test
- recreate RVR Wi-Fi config page when showing after removal to avoid widget deletion errors

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'close_wifi' from 'src.test')*


------
https://chatgpt.com/codex/tasks/task_e_689dabbab73c832bb05441fee0596827