### PR TITLE
feat: use pythonw for packaged runs

### DIFF
--- a/build.spec
+++ b/build.spec
@@ -1,6 +1,8 @@
 # build.spec
 import os
 import sys
+from pathlib import Path
+
 # 在build.spec顶部添加
 def get_requirements():
     with open('requirements.txt', 'r', encoding='utf-8') as f:
@@ -8,6 +10,7 @@ def get_requirements():
         return [line.strip().split('==')[0] for line in f if line.strip() and not line.startswith('#')]
 
 requirements = get_requirements()
+pythonw_path = str(Path(sys.executable).with_name('pythonw.exe'))
 a = Analysis(
     ['main.py'],  # 入口文件
     pathex=['.'],
@@ -16,6 +19,7 @@ a = Analysis(
         ('src/pytest.ini', 'src'),
         ('src/test', 'src/test'),
         ('config/performance_test_csv', 'config/performance_test_csv'),
+        (pythonw_path, '.'),
     ],
     hiddenimports=[
         # 手动添加PyQt5和自定义模块的隐藏依赖

--- a/src/ui/run.py
+++ b/src/ui/run.py
@@ -61,8 +61,13 @@ class CaseRunner(QThread):
 
             load_config(refresh=True)
 
+            if getattr(sys, "frozen", False):  # 打包环境
+                python_path = Path(sys.executable).with_name("pythonw.exe")
+            else:
+                python_path = sys.executable
+
             cmd = [
-                sys.executable,
+                python_path,
                 "-m",
                 "pytest",
                 "-v",


### PR DESCRIPTION
## Summary
- allow CaseRunner to invoke pythonw.exe when running in frozen environment
- package pythonw.exe via PyInstaller spec

## Testing
- `python -m py_compile src/ui/run.py build.spec`
- `pytest src/ui -q` *(fails: adb not found; TypeError in TestResult)*

------
https://chatgpt.com/codex/tasks/task_e_689eca59d5c8832b85ebdc121abf9e0b