### PR TITLE
feat: 支持自定义路由器网关

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,6 +25,7 @@ rf_solution:
   - 70
 router:
   name: asusax88u
+  address: 192.168.50.1
   ssid_2g: asusax88u_2g
   passwd_2g: '12345678'
   ssid_5g: asusax88u_5g

--- a/config/router_xpath/asus_xpath.yaml
+++ b/config/router_xpath/asus_xpath.yaml
@@ -1,11 +1,6 @@
 # This is yaml for ASUS router xpath info
 
 asus:
-  address:
-    '5400': http://192.168.1.1/
-    86u: http://192.168.50.1/
-    88u: http://192.168.5.1/
-    '6700': http://192.168.8.1/
   account: admin
   passwd: 12345678
   username_element: login_username

--- a/config/router_xpath/h3c_xpath.yaml
+++ b/config/router_xpath/h3c_xpath.yaml
@@ -1,8 +1,6 @@
 # This is yaml for h3c router xpath info
 
 h3c:
-  address:
-    bx54: http://192.168.4.1/router_password_mobile.asp
   passwd: 12345678
   password_element: psd
   signin_element: login

--- a/config/router_xpath/linksys_xpath.yaml
+++ b/config/router_xpath/linksys_xpath.yaml
@@ -1,8 +1,6 @@
 # This is yaml for linksys router xpath info
 
 linksys:
-  address:
-    1200ac: http://192.168.3.1/
   passwd: 12345678
   password_element: adminPass
   signin_element: submit-login

--- a/config/router_xpath/netgear_xpath.yaml
+++ b/config/router_xpath/netgear_xpath.yaml
@@ -1,7 +1,5 @@
 # This is yaml for NETGEAR router xpath info
 netgear:
-  address:
-    R6100: http://192.168.9.1
   account: admin
   passwd: '12345678'
 

--- a/config/router_xpath/tplink_xpath.yaml
+++ b/config/router_xpath/tplink_xpath.yaml
@@ -1,9 +1,6 @@
 # This is yaml for h3c router xpath info
 
 tplink:
-  address:
-    ax6000: http://192.168.5.1
-    wr842: http://192.168.7.1
   passwd: 12345678
   password_element:
     ax6000: lgPwd

--- a/config/router_xpath/xiaomi_xpath.yaml
+++ b/config/router_xpath/xiaomi_xpath.yaml
@@ -1,10 +1,6 @@
 # This is yaml for xiaomi router xpath info
 
 xiaomi:
-  address:
-    be7000: http://192.168.31.1/cgi-bin/luci/web
-    ax3600: http://192.168.50.1/cgi-bin/luci/web
-    ax3000: http://192.168.1.1/
   passwd: 12345678
   password_element: password
   signin_element: btnRtSubmit

--- a/config/router_xpath/zte_xpath.yaml
+++ b/config/router_xpath/zte_xpath.yaml
@@ -1,8 +1,6 @@
 # This is yaml for zte router xpath info
 
 zte:
-  address:
-    ax5400: http://192.168.2.1
   passwd: 12345678
   password_element: txtPwd
   signin_element: btnLogin

--- a/src/tools/router_tool/AsusRouter/Asusax86uControl.py
+++ b/src/tools/router_tool/AsusRouter/Asusax86uControl.py
@@ -41,8 +41,8 @@ class Asusax86uControl(RouterTools):
         '13': '14',
     }
 
-    def __init__(self):
-        super().__init__('asus_86u', display=True)
+    def __init__(self, address: str | None = None):
+        super().__init__('asus_86u', display=True, address=address)
 
     def change_setting(self, router):
         '''

--- a/src/tools/router_tool/AsusRouter/Asusax88uControl.py
+++ b/src/tools/router_tool/AsusRouter/Asusax88uControl.py
@@ -8,16 +8,12 @@
 
 
 import logging
-import os
 import telnetlib
 import time
-
-from urllib.parse import urlparse
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from src.tools.yamlTool import yamlTool
 from src.tools.router_tool.RouterControl import ConfigError, RouterTools
 
 
@@ -104,11 +100,9 @@ class Asusax88uControl(RouterTools):
         '161': '13',
     }
 
-    def __init__(self):
-        self.yaml_info = yamlTool(os.getcwd() + f'\\config\\router_xpath\\asus_xpath.yaml')
-        self.xpath = self.yaml_info.get_note('asus')
-        addr = self.xpath['address']['88u']
-        self.host = urlparse(addr).hostname or addr
+    def __init__(self, address: str | None = None):
+        super().__init__('asus_88u', display=True, address=address)
+        self.host = self.address
         self.port = 23
         self.prompt = b'admin@RT-AX88U-D8C0:/tmp/home/root#'  # 命令提示符
         self.tn = None

--- a/src/tools/router_tool/H3CBX54Control.py
+++ b/src/tools/router_tool/H3CBX54Control.py
@@ -32,7 +32,7 @@ class H3CBX54Control():
     def login(self):
         # click login
         try:
-            self.router_control.driver.get(self.router_control.address)
+            self.router_control.driver.get(f"http://{self.router_control.address}")
             self.router_control.driver.find_element(By.ID, self.router_control.xpath['signin_element']).click()
             # input passwd
             self.router_control.driver.find_element(By.ID, self.router_control.xpath['password_element']).click()

--- a/src/tools/router_tool/NetgearR6100Control.py
+++ b/src/tools/router_tool/NetgearR6100Control.py
@@ -26,7 +26,7 @@ class NetgearR6100Control():
 
     def login(self):
         try:
-            self.router_control.driver.get(self.router_control.address)
+            self.router_control.driver.get(f"http://{self.router_control.address}")
             self.keyboard.type_string(self.router_control.xpath["account"])  # 输入账号
             # self.keyboard.tap_key(self.keyboard.enter_key)  # 按enter，如果默认输入法是英文，请注销此行
             sleep(1)

--- a/src/tools/router_tool/RouterControl.py
+++ b/src/tools/router_tool/RouterControl.py
@@ -8,7 +8,6 @@
 
 import logging
 import os
-import re
 import time
 from abc import ABCMeta, abstractmethod
 
@@ -126,7 +125,19 @@ class RouterTools(RouterControl):
         '澳大利亚': '8'
     }
 
-    def __init__(self, router_info, display=True):
+    def __init__(self, router_info, display=True, address: str | None = None):
+        """初始化路由器控制对象
+
+        Parameters
+        ----------
+        router_info: str
+            路由器信息，格式为 ``品牌_型号``
+        display: bool
+            是否显示浏览器界面
+        address: str | None
+            路由器网关地址，如果为空则使用默认值
+        """
+
         # 路由器品牌
         self.router_type = router_info.split("_")[0]
         # 路由器完整信息
@@ -135,15 +146,21 @@ class RouterTools(RouterControl):
         self.yaml_info = yamlTool(os.getcwd() + f'\\config\\router_xpath\\{self.router_type.split("_")[0]}_xpath.yaml')
         # self.yaml_info = yamlTool(fr'D:\PycharmProjects\wifi_test\config\router_xpath\{self.router_type}_xpath.yaml')
         # 元素配置文件 根节点
-
         self.xpath = self.yaml_info.get_note(self.router_type)
-        # print(self.xpath['address'])
-        # print(router_info.split("_")[1])
 
-        # 路由器登录 地址
-        self.address = self.xpath['address'][router_info.split("_")[1]]
+        # 路由器登录地址，优先使用传入参数，其次使用预设默认值
+        default_address = {
+            'xiaomi': '192.168.31.1',
+            'asus': '192.168.50.1',
+            'h3c': '192.168.4.1',
+            'linksys': '192.168.3.1',
+            'netgear': '192.168.9.1',
+            'tplink': '192.168.5.1',
+            'zte': '192.168.2.1'
+        }.get(self.router_type, '192.168.1.1')
+        self.address = address or default_address
         logging.info(self.address)
-        self.ping_address = re.findall(r"\d+\.\d+\.\d+\.\d+", self.address)[0]
+        self.ping_address = self.address
 
         # 全局等待3秒 （当driver 去查询 控件时生效）
 

--- a/src/tools/router_tool/Tplink/TplinkAx6000Control.py
+++ b/src/tools/router_tool/Tplink/TplinkAx6000Control.py
@@ -29,7 +29,7 @@ class TplinkAx6000Control:
 
     def login(self):
         # try:
-        self.router_control.driver.get(self.router_control.address)
+        self.router_control.driver.get(f"http://{self.router_control.address}")
         # input passwd
         self.router_control.driver.find_element(By.ID, self.router_control.xpath['password_element'][self.type]).click()
         self.router_control.driver.find_element(By.ID,

--- a/src/tools/router_tool/Tplink/TplinkWr842Control.py
+++ b/src/tools/router_tool/Tplink/TplinkWr842Control.py
@@ -30,7 +30,7 @@ class TplinkWr842Control:
     def login(self):
         # click login
         # try:
-        self.router_control.driver.get(self.router_control.address)
+        self.router_control.driver.get(f"http://{self.router_control.address}")
         self.router_control.driver.find_element(
             By.ID, self.router_control.xpath['password_element'][self.type]).click()
         self.router_control.driver.find_element(

--- a/src/tools/router_tool/Xiaomi/XiaomiBe7000Control.py
+++ b/src/tools/router_tool/Xiaomi/XiaomiBe7000Control.py
@@ -80,13 +80,13 @@ class XiaomiBe7000Control(RouterTools):
     WIRELESS_2 = ['11n', '11ax']
     WIRELESS_5 = ['11ac', '11ax']
 
-    def __init__(self):
-        super().__init__('xiaomi_be7000', display=True)
+    def __init__(self, address: str | None = None):
+        super().__init__('xiaomi_be7000', display=True, address=address)
 
     def login(self):
         super().login()
         # try:
-        self.driver.get(self.address)
+        self.driver.get(f"http://{self.address}")
         # input passwd
         self.driver.find_element(By.ID, self.xpath['password_element']).click()
         self.driver.find_element(By.ID, self.xpath['password_element']).clear()

--- a/src/tools/router_tool/Xiaomi/Xiaomiax3600Control.py
+++ b/src/tools/router_tool/Xiaomi/Xiaomiax3600Control.py
@@ -83,8 +83,8 @@ class Xiaomiax3600Control(RouterTools):
     WIRELESS_2 = ['11n', '11ax']
     WIRELESS_5 = ['11ac', '11ax']
 
-    def __init__(self):
-        super().__init__('xiaomi_ax3600', display=True)
+    def __init__(self, address: str | None = None):
+        super().__init__('xiaomi_ax3600', display=True, address=address)
 
     def login(self):
         '''
@@ -94,7 +94,7 @@ class Xiaomiax3600Control(RouterTools):
         '''
         # try:
         super().login()
-        self.driver.get(self.address)
+        self.driver.get(f"http://{self.address}")
         # input passwd
         self.driver.find_element(By.ID, self.xpath['password_element']).click()
         time.sleep(0.5)

--- a/src/tools/router_tool/ZTEax5400Control.py
+++ b/src/tools/router_tool/ZTEax5400Control.py
@@ -23,7 +23,7 @@ class ZTEax5400Control():
 
         # click login
         # try:
-        self.router_control.driver.get(self.router_control.address)
+        self.router_control.driver.get(f"http://{self.router_control.address}")
         # input passwd
         self.router_control.driver.find_element(By.ID, self.router_control.xpath['password_element']).click()
         self.router_control.driver.find_element(By.ID, self.router_control.xpath['password_element']).send_keys(

--- a/src/tools/router_tool/router_factory.py
+++ b/src/tools/router_tool/router_factory.py
@@ -15,12 +15,39 @@ from src.tools.router_tool.AsusRouter.Asusax5400Control import Asusax5400Control
 from src.tools.router_tool.AsusRouter.Asusax6700Control import Asusax6700Control
 from src.tools.router_tool.Xiaomi.Xiaomiax3600Control import Xiaomiax3600Control
 from src.tools.router_tool.Xiaomi.XiaomiBe7000Control import XiaomiBe7000Control
+from src.tools.config_loader import load_config
 
-router_list = {'asusax86u': Asusax86uControl, 'asusax88u': Asusax88uControl, 'asusax5400': Asusax5400Control,
-          'asusax6700': Asusax6700Control, 'xiaomibe7000': XiaomiBe7000Control,
-          'xiaomiax3600': Xiaomiax3600Control}
+router_list = {
+    'asusax86u': Asusax86uControl,
+    'asusax88u': Asusax88uControl,
+    'asusax5400': Asusax5400Control,
+    'asusax6700': Asusax6700Control,
+    'xiaomibe7000': XiaomiBe7000Control,
+    'xiaomiax3600': Xiaomiax3600Control,
+}
 
-def get_router(router_name):
 
-    if router_name not in router_list.keys(): raise ValueError("Doesn't support this router")
-    return router_list[router_name]()
+def get_router(router_name: str, address: str | None = None):
+    """根据路由器名称获取对应控制对象
+
+    Parameters
+    ----------
+    router_name: str
+        路由器名称
+    address: str | None
+        指定的网关地址，若为空则尝试从配置文件读取
+    """
+
+    if router_name not in router_list:
+        raise ValueError("Doesn't support this router")
+
+    if address is None:
+        try:
+            cfg = load_config()
+            cfg_router = cfg.get('router', {})
+            if cfg_router.get('name') == router_name:
+                address = cfg_router.get('address')
+        except Exception:
+            address = None
+
+    return router_list[router_name](address)


### PR DESCRIPTION
## Summary
- 移除路由器 XPath 配置中的 address 字段，改由 RouterControl 提供品牌默认网关并可传入自定义地址
- CaseConfigPage 新增网关输入框并与路由器对象同步，动态更新 router_factory 与 RvrWifiConfig 的加载逻辑
- 所有路由器登录和 Telnet 操作统一从对象属性获取地址

## Testing
- `python -m py_compile src/tools/router_tool/router_factory.py src/ui/windows_case_config.py src/ui/rvr_wifi_config.py src/tools/router_tool/AsusRouter/Asusax88uControl.py`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'pytest.log')*

------
https://chatgpt.com/codex/tasks/task_e_68a070819268832bbd79e44c602cbf36