### PR TITLE
添加调试打印以排查页面显示问题

### DIFF
--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -951,7 +951,9 @@ class CaseConfigPage(CardWidget):
 
         main_window = self.window()
         if hasattr(main_window, "setCurrentIndex"):
+            print("get_editable_fields: before switch to case_config_page")
             main_window.setCurrentIndex(main_window.case_config_page)
+            print("get_editable_fields: after switch to case_config_page")
 
         if info.enable_rvr_wifi:
             ssid = ""
@@ -963,10 +965,14 @@ class CaseConfigPage(CardWidget):
             if isinstance(passwd_widget, LineEdit):
                 passwd = passwd_widget.text()
             if hasattr(main_window, "show_rvr_wifi_config"):
+                print("get_editable_fields: before show_rvr_wifi_config")
                 main_window.show_rvr_wifi_config()
+                print("get_editable_fields: after show_rvr_wifi_config")
         else:
             if hasattr(main_window, "hide_rvr_wifi_config"):
+                print("get_editable_fields: before hide_rvr_wifi_config")
                 main_window.hide_rvr_wifi_config()
+                print("get_editable_fields: after hide_rvr_wifi_config")
         if hasattr(self, "csv_combo"):
             if info.enable_csv:
                 self.csv_combo.setEnabled(True)


### PR DESCRIPTION
## Summary
- 在 `show_rvr_wifi_config`、`hide_rvr_wifi_config` 等位置加入打印以追踪导航项与页面状态
- 新增 `_add_interface` 打印添加页面前后的数量，增强 `_remove_interface` 的状态输出
- 在用例切换逻辑中打印调用顺序，便于确认性能用例切换时的接口显示与隐藏

## Testing
- `python -m py_compile main.py src/ui/windows_case_config.py`
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68a1beda38d4832ba8a7760191510dbc