### PR TITLE
fix rvr wifi page removal

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,8 +115,8 @@ class MainWindow(FluentWindow):
         self.rvr_wifi_config_page = None
         print("hide_rvr_wifi_config end: page=", self.rvr_wifi_config_page)
 
-    def removeSubInterface(self, page):
-        """Remove the given page from the navigation if possible."""
+    def _detach_sub_interface(self, page):
+        """Detach the given page from the navigation if possible."""
         if hasattr(self, "navigationInterface"):
             for name in ("removeSubInterface", "removeInterface", "removeItem"):
                 func = getattr(self.navigationInterface, name, None)
@@ -155,13 +155,6 @@ class MainWindow(FluentWindow):
         )
         nav = getattr(self, "navigationInterface", None)
 
-        if widget is self.rvr_wifi_config_page and self._rvr_nav_button:
-            if nav:
-                with suppress(Exception):
-                    nav.removeWidget(self._rvr_nav_button)
-            self._rvr_nav_button.deleteLater()
-            self._rvr_nav_button = None
-
         buttons = []
         if nav:
             buttons = [
@@ -185,10 +178,14 @@ class MainWindow(FluentWindow):
             logging.info(
                 "Removing from navigationInterface id=%s", id(widget) if widget else None
             )
-            self.removeSubInterface(widget)
+            FluentWindow.removeSubInterface(self, widget)
             logging.info(
                 "Removed from navigationInterface id=%s", id(widget) if widget else None
             )
+
+        if widget is self.rvr_wifi_config_page and self._rvr_nav_button:
+            self._rvr_nav_button.deleteLater()
+            self._rvr_nav_button = None
 
         if nav:
             leftover = [


### PR DESCRIPTION
## Summary
- rename custom `removeSubInterface` helper to `_detach_sub_interface`
- use `FluentWindow.removeSubInterface` when removing pages and clear `_rvr_nav_button`

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
try:
    from main import MainWindow
    from PyQt5.QtWidgets import QApplication
    import sys
    app = QApplication(sys.argv)
    win = MainWindow()
    win.show_rvr_wifi_config()
    win.hide_rvr_wifi_config()
    print('simulate success')
except Exception as e:
    print('Error:', e)
PY` *(fails: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68a1c30dee0c832b95c06e59aebc952c