### PR TITLE
feat: improve interface removal

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,6 +160,7 @@ class MainWindow(FluentWindow):
             self.stackedWidget.currentWidget(),
         )
         nav = getattr(self, "navigationInterface", None)
+        nav_count_before = len(nav.findChildren(QAbstractButton)) if nav else 0
 
         buttons = []
         if nav:
@@ -184,7 +185,10 @@ class MainWindow(FluentWindow):
             logging.info(
                 "Removing from navigationInterface id=%s", id(widget) if widget else None
             )
-            FluentWindow.removeSubInterface(self, widget)
+            if nav and hasattr(nav, "removeItem"):
+                nav.removeItem(widget.objectName())
+            else:
+                self.removeInterface(widget)
             logging.info(
                 "Removed from navigationInterface id=%s", id(widget) if widget else None
             )
@@ -231,6 +235,9 @@ class MainWindow(FluentWindow):
             self.stackedWidget.count(),
             "rvr_wifi_config_page=",
             self.rvr_wifi_config_page,
+        )
+        logging.info(
+            "Nav buttons: %s -> %s", nav_count_before, nav_after
         )
         logging.info("_remove_interface end id=%s index=%s", id(widget), idx)
 


### PR DESCRIPTION
## Summary
- use navigationInterface.removeItem when removing a sub interface
- log navigation button count before and after removal

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68a1cf64d0a0832b9a043c102dec5558