### PR TITLE
refactor: rename authentication field to security_protocol

### DIFF
--- a/config/compatibility_router.json
+++ b/config/compatibility_router.json
@@ -6,12 +6,12 @@
         "model": "RT-AX88U PRO",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -22,12 +22,12 @@
         "model": "AX3000 RA80",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -38,12 +38,12 @@
         "model": "AX1800 RAX20",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -54,12 +54,12 @@
         "model": "TL-XDR6030YIZHANBAN",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -70,12 +70,12 @@
         "model": "RT-AC1900P",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -86,12 +86,12 @@
         "model": "JD12LPROXINHAOZENGQIANGBAN",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -102,12 +102,12 @@
         "model": "BE6LPRO",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -118,12 +118,12 @@
         "model": "CF-WR633AX",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -134,12 +134,12 @@
         "model": "TL-7DR7230YIZHANBAN",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -150,12 +150,12 @@
         "model": "ZXSLC SR7410",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -166,12 +166,12 @@
         "model": "AX3PRO WS7206",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -182,12 +182,12 @@
         "model": "XIHE-BE70",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -198,12 +198,12 @@
         "model": "ZXSLC SR6110",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -214,12 +214,12 @@
         "model": "D126",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -230,12 +230,12 @@
         "model": "X4PRO HLB-600",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -246,12 +246,12 @@
         "model": "NX30PRO",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -262,12 +262,12 @@
         "model": "SR5301ZA",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -278,12 +278,12 @@
         "model": "BE3600 RD15",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -294,12 +294,12 @@
         "model": "R4A",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -310,12 +310,12 @@
         "model": "AX3000T RD03",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -326,12 +326,12 @@
         "model": "TL-XDR5410YIZHANBAN",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -342,12 +342,12 @@
         "model": "MAGIC NX54",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -358,12 +358,12 @@
         "model": "TL-WDR7660QIANZHAOYIZHANBAN",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -374,12 +374,12 @@
         "model": "TX-AX6000",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -390,12 +390,12 @@
         "model": "XD4 PRO",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -406,12 +406,12 @@
         "model": "RAX50",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -422,12 +422,12 @@
         "model": "RAX70",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -438,12 +438,12 @@
         "model": "RG-EW1300G",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -454,12 +454,12 @@
         "model": "X60",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -470,12 +470,12 @@
         "model": "LK-DS7587",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -486,12 +486,12 @@
         "model": "TL-7DR3630YIZHANBAN",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -502,12 +502,12 @@
         "model": "E8450",
         "2.4G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -518,12 +518,12 @@
         "model": "TR4400",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -534,12 +534,12 @@
         "model": "SBR-AC1200P",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -550,12 +550,12 @@
         "model": "W21",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -566,12 +566,12 @@
         "model": "BE7",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -582,12 +582,12 @@
         "model": "WZR-1750DHP",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -598,12 +598,12 @@
         "model": "BE3 PRO",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -614,12 +614,12 @@
         "model": "TG3452",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         }
     },
@@ -630,12 +630,12 @@
         "model": "SDX62",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AX",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -646,12 +646,12 @@
         "model": "2AFZUSAP102",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     },
@@ -662,12 +662,12 @@
         "model": "SBR-AC1750",
         "2.4G": {
             "mode": "11N",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "20MHz"
         },
         "5G": {
             "mode": "11AC",
-            "authentication": "wpa2",
+            "security_protocol": "wpa2",
             "bandwidth": "80MHz"
         }
     }

--- a/config/performance_test_csv/asus/rvr_wifi_setup.csv
+++ b/config/performance_test_csv/asus/rvr_wifi_setup.csv
@@ -1,3 +1,3 @@
-band,ssid,wireless_mode,channel,bandwidth,authentication,password,tx,rx,data_row
+band,ssid,wireless_mode,channel,bandwidth,security_protocol,password,tx,rx,data_row
 5G,asus88u_2g,11ac,自动,20/40/80 MHz,WPA2-Personal, 12345678,1,1,
 2.4G,asus88u_5g,11n,自动,20/40 MHz,Open System, ,1,1,

--- a/config/performance_test_csv/asus/rvr_wifi_setup_demo.csv
+++ b/config/performance_test_csv/asus/rvr_wifi_setup_demo.csv
@@ -1,2 +1,2 @@
-band,ssid,wireless_mode,channel,bandwidth,authentication,password,tx,rx,data_row
+band,ssid,wireless_mode,channel,bandwidth,security_protocol,password,tx,rx,data_row
 5G,asus88u_2g,11ac,自动,20/40/80 MHz,WPA2-Personal, 12345678,0,1,

--- a/config/performance_test_csv/xiaomi/rvr_wifi_setup.csv
+++ b/config/performance_test_csv/xiaomi/rvr_wifi_setup.csv
@@ -1,2 +1,2 @@
-band,ssid,wireless_mode,channel,bandwidth,authentication,password,tx,rx,data_row
+band,ssid,wireless_mode,channel,bandwidth,security_protocol,password,tx,rx,data_row
 2.4G,xiaomibe7000_2g,11n,自动,20MHz,强加密(WPA2个人版),12345678,1,1,

--- a/config/wifi_compatibility_data/asusax5400.bat.csv
+++ b/config/wifi_compatibility_data/asusax5400.bat.csv
@@ -1,4 +1,4 @@
-serial,band   ,ssid           ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band   ,ssid           ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,ASUSAX5400_2.4G,自动       ,1,20 MHz      ,Open System           ,           ,tx rx    ,TCP          ,           ,        ,否         ,
 2,2.4G,ASUSAX5400_2.4G,自动       ,1,40 MHz      ,WPA2-Personal       ,12345678,tx rx    ,TCP          ,           ,        ,否         ,
 3,2.4G,ASUSAX5400_2.4G,自动       ,2,20/40 MHz   ,WPA3-Personal         ,12345678,tx rx    ,TCP          ,           ,        ,是         ,SAE

--- a/config/wifi_compatibility_data/asusax5400.csv
+++ b/config/wifi_compatibility_data/asusax5400.csv
@@ -1,4 +1,4 @@
-serial,band   ,ssid           ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band   ,ssid           ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,ASUSAX5400_2.4G,自动       ,1,20 MHz      ,Open System           ,           ,tx rx    ,TCP          ,           ,        ,否         ,
 2,2.4G,ASUSAX5400_2.4G,自动       ,1,40 MHz      ,WPA2-Personal       ,12345678,tx rx    ,TCP          ,           ,        ,否         ,
 3,2.4G,ASUSAX5400_2.4G,自动       ,2,20/40 MHz   ,WPA3-Personal         ,12345678,tx rx    ,TCP          ,           ,        ,是         ,SAE

--- a/config/wifi_compatibility_data/asusax88u.csv
+++ b/config/wifi_compatibility_data/asusax88u.csv
@@ -1,3 +1,3 @@
-serial,band   ,ssid              ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type
+serial,band   ,ssid              ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type
 1,2.4G,ASUSAC68U_ATC_2.4G,N only       ,1      ,40 MHz   ,WPA2-Personal        ,12345678  ,tx rx    ,TCP
 2,5G  ,ASUSAC68U_ATC_5G  ,N/AC/AX mixed,161    ,80 MHz   ,WPA2-Personal        ,12345678  ,rx tx    ,TCP

--- a/config/wifi_compatibility_data/asusea6700.bat.csv
+++ b/config/wifi_compatibility_data/asusea6700.bat.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
 1,2.4G,Asusea6700_2.4G,自动,自动,20/40 MHz,Open System,,tx rx,TCP,,,是,NONE,,,
 2,2.4G,Asusea6700_2.4G,自动,1,20/40 MHz,WPA2-Personal,12345678,tx rx,TCP,,,否,,,,
 3,2.4G,Asusea6700_2.4G,自动,2,20/40 MHz,WPA-Auto-Personal,12345678,tx rx,TCP,,,否,,,,

--- a/config/wifi_compatibility_data/asusea6700.csv
+++ b/config/wifi_compatibility_data/asusea6700.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
 1,2.4G,Asusea6700_2.4G,自动,自动,20/40 MHz,Open System,,tx rx,TCP,,,是,NONE,,,
 2,2.4G,Asusea6700_2.4G,自动,1,20/40 MHz,WPA2-Personal,12345678,tx rx,TCP,,,否,,,,
 3,2.4G,Asusea6700_2.4G,自动,2,20/40 MHz,WPA-Auto-Personal,12345678,tx rx,TCP,,,否,,,,

--- a/config/wifi_compatibility_data/h3cbx54.bat.csv
+++ b/config/wifi_compatibility_data/h3cbx54.bat.csv
@@ -1,4 +1,4 @@
-serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,H3CBX54_2.4G,b-only       ,AUTO   ,20M      ,WPA-PSK/WPA2-PSK混合  ,12345678,tx rx    ,TCP          ,           ,          ,否        ,
 2,2.4G,H3CBX54_2.4G,b-only       ,1,20M      ,不加密                ,          ,tx rx    ,TCP           ,           ,          ,否        ,
 3,2.4G,H3CBX54_2.4G,b-only       ,2,20M      ,WPA2-PSK             ,12345678,tx rx    ,TCP           ,           ,          ,是        ,PSK

--- a/config/wifi_compatibility_data/h3cbx54.csv
+++ b/config/wifi_compatibility_data/h3cbx54.csv
@@ -1,4 +1,4 @@
-serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,H3CBX54_2.4G,b-only       ,AUTO   ,20M      ,WPA-PSK/WPA2-PSK混合  ,12345678,tx rx    ,TCP          ,           ,          ,否        ,
 2,2.4G,H3CBX54_2.4G,b-only       ,1,20M      ,不加密                ,          ,tx rx    ,TCP           ,           ,          ,否        ,
 3,2.4G,H3CBX54_2.4G,b-only       ,2,20M      ,WPA2-PSK             ,12345678,tx rx    ,TCP           ,           ,          ,是        ,PSK

--- a/config/wifi_compatibility_data/linksys1200ac.bat.csv
+++ b/config/wifi_compatibility_data/linksys1200ac.bat.csv
@@ -1,4 +1,4 @@
-serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,Linksys1200ac_2.4G,混合模式,1,仅使用20 MHz,无,,tx rx,TCP,,,否,
 2,2.4G,Linksys1200ac_2.4G,混合模式,1,仅使用20 MHz,WPA2个人,12345678,tx rx,TCP,,,否,
 3,2.4G,Linksys1200ac_2.4G,混合模式,2,仅使用20 MHz,WPA2/WPA混合个人模式,12345678,tx rx,TCP,,,是,PSK

--- a/config/wifi_compatibility_data/linksys1200ac.csv
+++ b/config/wifi_compatibility_data/linksys1200ac.csv
@@ -1,4 +1,4 @@
-serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial    ,band   ,ssid        ,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,Linksys1200ac_2.4G,混合模式,1,仅使用20 MHz,无,,tx rx,TCP,,,否,
 2,2.4G,Linksys1200ac_2.4G,混合模式,1,仅使用20 MHz,WPA2个人,12345678,tx rx,TCP,,,否,
 3,2.4G,Linksys1200ac_2.4G,混合模式,2,仅使用20 MHz,WPA2/WPA混合个人模式,12345678,tx rx,TCP,,,是,PSK

--- a/config/wifi_compatibility_data/netgearR6100.bat.csv
+++ b/config/wifi_compatibility_data/netgearR6100.bat.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,NetgearR6100_2G,54Mbps,AUTO,,None,,tx rx,TCP,,,否,
 2,2.4G,NetgearR6100_2G,54Mbps,1,,WEP,,tx rx,TCP,wep-64,12345,否,
 3,2.4G,NetgearR6100_2G,54Mbps,2,,WEP,,tx rx,TCP,wep-128,12345678901234567890123456,否,

--- a/config/wifi_compatibility_data/netgearR6100.csv
+++ b/config/wifi_compatibility_data/netgearR6100.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,NetgearR6100_2G,54Mbps,AUTO,,None,,tx rx,TCP,,,否,
 2,2.4G,NetgearR6100_2G,54Mbps,1,,WEP,,tx rx,TCP,wep-64,12345,否,
 3,2.4G,NetgearR6100_2G,54Mbps,2,,WEP,,tx rx,TCP,wep-128,12345678901234567890123456,否,

--- a/config/wifi_compatibility_data/tplinkax6000.bat.csv
+++ b/config/wifi_compatibility_data/tplinkax6000.bat.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,自动,40MHz/20MHz自动,WPA-PSK/WPA2-PSK,amlogic_wifi123,,,,,否,
 2,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,自动,40MHz/20MHz自动,WPA2-PSK/WPA3-SAE,12345678,,,,,否,
 3,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,1,40MHz/20MHz自动,WPA-PSK/WPA2-PSK,amlogic_wifi123,,,,,否,

--- a/config/wifi_compatibility_data/tplinkax6000.csv
+++ b/config/wifi_compatibility_data/tplinkax6000.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,自动,40MHz/20MHz自动,WPA-PSK/WPA2-PSK,amlogic_wifi123,,,,,否,
 2,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,自动,40MHz/20MHz自动,WPA2-PSK/WPA3-SAE,12345678,,,,,否,
 3,2.4G,Tplinkax6000_2.4G#$,11bgn/ax mixed,1,40MHz/20MHz自动,WPA-PSK/WPA2-PSK,amlogic_wifi123,,,,,否,

--- a/config/wifi_compatibility_data/tplinkwr842.bat.csv
+++ b/config/wifi_compatibility_data/tplinkwr842.bat.csv
@@ -1,4 +1,4 @@
-serial   ,band   ,ssid           ,wireless_mode,channel,bandwidth   ,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
+serial   ,band   ,ssid           ,wireless_mode,channel,bandwidth   ,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
 1,2.4G,Tplinkwr842_2.4G#$,11b only,自动,20MHz,OPEN,,tx rx    ,TCP          ,,,否,,,,
 2,2.4G,Tplinkwr842_2.4G#$,11b only,1,20MHz,WPA-PSK,12345678,tx rx    ,TCP          ,,,否,,TKIP,,
 3,2.4G,Tplinkwr842_2.4G#$,11b only,2,20MHz,WPA-PSK,12345678,tx rx    ,TCP          ,,,否,,AES,,

--- a/config/wifi_compatibility_data/tplinkwr842.csv
+++ b/config/wifi_compatibility_data/tplinkwr842.csv
@@ -1,4 +1,4 @@
-serial   ,band   ,ssid           ,wireless_mode,channel,bandwidth   ,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
+serial   ,band   ,ssid           ,wireless_mode,channel,bandwidth   ,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type,wpa_encrypt,passwd_index,protect_frame
 1,2.4G,Tplinkwr842_2.4G#$,11b only,自动,20MHz,OPEN,,tx rx    ,TCP          ,,,否,,,,
 2,2.4G,Tplinkwr842_2.4G#$,11b only,1,20MHz,WPA-PSK,12345678,tx rx    ,TCP          ,,,否,,TKIP,,
 3,2.4G,Tplinkwr842_2.4G#$,11b only,2,20MHz,WPA-PSK,12345678,tx rx    ,TCP          ,,,否,,AES,,

--- a/config/wifi_compatibility_data/xiaomiax3000.bat.csv
+++ b/config/wifi_compatibility_data/xiaomiax3000.bat.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,XiaomiAX3000_2.4G,,1,40/20MHz,超强加密(WPA3个人版),12345678,tx rx,TCP,,,否,
 2,2.4G,XiaomiAX3000_2.4G,,2,20MHz,强混合加密(WPA3/WPA2个人版),12345678,tx rx,TCP,,,是,PSK
 3,2.4G,XiaomiAX3000_2.4G,,3,40MHz,强加密(WPA2个人版),12345678,tx rx,TCP,,,否,

--- a/config/wifi_compatibility_data/xiaomiax3000.csv
+++ b/config/wifi_compatibility_data/xiaomiax3000.csv
@@ -1,4 +1,4 @@
-serial,band,ssid,wireless_mode,channel,bandwidth,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial,band,ssid,wireless_mode,channel,bandwidth,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,XiaomiAX3000_2.4G,,1,40/20MHz,超强加密(WPA3个人版),12345678,tx rx,TCP,,,否,
 2,2.4G,XiaomiAX3000_2.4G,,2,20MHz,强混合加密(WPA3/WPA2个人版),12345678,tx rx,TCP,,,是,PSK
 3,2.4G,XiaomiAX3000_2.4G,,3,40MHz,强加密(WPA2个人版),12345678,tx rx,TCP,,,否,

--- a/config/wifi_compatibility_data/zteax5400.bat.csv
+++ b/config/wifi_compatibility_data/zteax5400.bat.csv
@@ -1,4 +1,4 @@
-serial   ,band   ,ssid          ,wireless_mode         ,channel,bandwidth               ,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial   ,band   ,ssid          ,wireless_mode         ,channel,bandwidth               ,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,ZTEax5400_2.4G,802.11 b/g/n             ,1,20MHz                   ,OPEN                 ,          ,tx rx    ,TCP          ,           ,          ,否        ,
 2,2.4G,ZTEax5400_2.4G,802.11 b/g/n             ,1,40MHz                   ,WPA2(AES)-PSK        ,12345678,tx rx    ,TCP          ,           ,          ,是,PSK
 3,2.4G,ZTEax5400_2.4G,802.11 b/g/n             ,2,20MHz/40MHz             ,WPA-PSK/WPA2-PSK         ,12345678,tx rx    ,TCP          ,           ,          ,否        ,

--- a/config/wifi_compatibility_data/zteax5400.csv
+++ b/config/wifi_compatibility_data/zteax5400.csv
@@ -1,2 +1,2 @@
-serial   ,band   ,ssid          ,wireless_mode         ,channel,bandwidth               ,authentication,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
+serial   ,band   ,ssid          ,wireless_mode         ,channel,bandwidth               ,security_protocol,wpa_passwd,test_type,protocol_type,wep_encrypt,wep_passwd,hide_ssid,hide_type
 1,2.4G,ZTEax5400_2.4G,802.11 b/g/n             ,1,20MHz                   ,OPEN                 ,          ,tx rx    ,TCP          ,           ,          ,否        ,

--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -68,10 +68,10 @@ def get_testdata(router):
         ], "Pls check bandwidth info"
         if "Legacy" in i.wireless_mode:
             assert (
-                    i.authentication in router.AUTHENTICATION_METHOD_LEGCY
-            ), "Pls check authentication info"
+                    i.security_protocol in router.AUTHENTICATION_METHOD_LEGCY
+            ), "Pls check security protocol info"
         else:
             assert (
-                    i.authentication in router.AUTHENTICATION_METHOD
-            ), "Pls check authentication info"
+                    i.security_protocol in router.AUTHENTICATION_METHOD
+            ), "Pls check security protocol info"
     return test_data

--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -64,8 +64,8 @@ def setup(request):
         # 连接 网络 最多三次重试
         for _ in range(3):
             try:
-                type = 'wpa3' if 'WPA3' in router_info.authentication else 'wpa2'
-                if router_info.authentication.lower() in \
+                type = 'wpa3' if 'WPA3' in router_info.security_protocol else 'wpa2'
+                if router_info.security_protocol.lower() in \
                         ['open', '不加密', '无', 'open system', '无加密(允许所有人连接)', 'none']:
                     logging.info('no passwd')
                     cmd = pytest.dut.CMD_WIFI_CONNECT.format(router_info.ssid, "open", "")

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -83,8 +83,8 @@ def setup(request):
         else:
                 for _ in range(3):
                         try:
-                                type = 'wpa3' if 'WPA3' in router_info.authentication else 'wpa2'
-                                if router_info.authentication.lower() in \
+                                type = 'wpa3' if 'WPA3' in router_info.security_protocol else 'wpa2'
+                                if router_info.security_protocol.lower() in \
                                                 ['open', '不加密', '无', 'open system', '无加密(允许所有人连接)', 'none']:
                                         logging.info('no passwd')
                                         cmd = pytest.dut.CMD_WIFI_CONNECT.format(router_info.ssid, "open", "")

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -87,8 +87,8 @@ def setup(request):
     else:
         # 连接 网络 最多三次重试
         for _ in range(3):
-            type = 'wpa3' if 'WPA3' in router_info.authentication else 'wpa2'
-            if router_info.authentication.lower() in \
+            type = 'wpa3' if 'WPA3' in router_info.security_protocol else 'wpa2'
+            if router_info.security_protocol.lower() in \
                     ['open', '不加密', '无', 'open system', '无加密(允许所有人连接)', 'none']:
                 logging.info('no passwd')
                 cmd = pytest.dut.CMD_WIFI_CONNECT.format(router_info.ssid, "open", "")

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -109,8 +109,8 @@ def setup(request):
         # 连接 网络 最多三次重试
         for _ in range(3):
             try:
-                type = 'wpa3' if 'WPA3' in router_info.authentication else 'wpa2'
-                if router_info.authentication.lower() in \
+                type = 'wpa3' if 'WPA3' in router_info.security_protocol else 'wpa2'
+                if router_info.security_protocol.lower() in \
                         ['open', '不加密', '无', 'open system', '无加密(允许所有人连接)', 'none']:
                     logging.info('no passwd')
                     cmd = pytest.dut.CMD_WIFI_CONNECT.format(router_info.ssid, "open", "")

--- a/src/test/project/roku/UI/test_wifi_switch_band.py
+++ b/src/test/project/roku/UI/test_wifi_switch_band.py
@@ -27,10 +27,10 @@ Expected Result
 ssid = 'ATC_ASUS_AX88U'
 ssid_bat = 'ATC_ASUS_AX88U_bat'
 router_2g = Router(band='2.4G', ssid=ssid, wireless_mode='11n', channel='1', bandwidth='20 MHz',
-                   authentication='Open System')
+                   security_protocol='Open System')
 
 router_5g = Router(band='5G', ssid=ssid_bat, wireless_mode='11ac', channel='36', bandwidth='80 MHz',
-                   authentication='Open System')
+                   security_protocol='Open System')
 
 ax88uControl = Asusax88uControl()
 

--- a/src/tools/connect_tool/adb.py
+++ b/src/tools/connect_tool/adb.py
@@ -1595,8 +1595,8 @@ class adb(dut):
             raise Exception("Can't get hw addr")
 
     def get_wifi_cmd(self, router_info):
-        type = 'wpa3' if 'WPA3' in router_info.authentication else 'wpa2'
-        if router_info.authentication.lower() in \
+        type = 'wpa3' if 'WPA3' in router_info.security_protocol else 'wpa2'
+        if router_info.security_protocol.lower() in \
                 ['open', '不加密', '无', 'open system', '无加密(允许所有人连接)', 'none']:
             cmd = pytest.dut.CMD_WIFI_CONNECT.format(router_info.ssid, "open", "")
         else:

--- a/src/tools/connect_tool/dut.py
+++ b/src/tools/connect_tool/dut.py
@@ -369,7 +369,7 @@ class dut():
         router_cfg = {
             router_info.band: {
                 'mode': router_info.wireless_mode,
-                'authentication': router_info.authentication,
+                'security_protocol': router_info.security_protocol,
                 'bandwidth': router_info.bandwidth,
             }
         }
@@ -453,7 +453,7 @@ class dut():
         router_cfg = {
             router_info.band: {
                 'mode': router_info.wireless_mode,
-                'authentication': router_info.authentication,
+                'security_protocol': router_info.security_protocol,
                 'bandwidth': router_info.bandwidth,
             }
         }

--- a/src/tools/router_tool/AsusRouter/Asusax5400Control.py
+++ b/src/tools/router_tool/AsusRouter/Asusax5400Control.py
@@ -88,9 +88,9 @@ class Asusax5400Control:
                     raise ConfigError('bandwidth element error')
                 self.router_control.change_bandwidth(router.bandwidth)
 
-            # 修改 authentication
-            if router.authentication:
-                self.router_control.change_authentication(router.authentication)
+            # 修改 security_protocol
+            if router.security_protocol:
+                self.router_control.change_authentication(router.security_protocol)
 
             # 修改 wep_encrypt
             if router.wep_encrypt:
@@ -155,7 +155,7 @@ class Asusax5400Control:
         finally:
             self.router_control.driver.quit()
 
-# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication', 'wep_encrypt',
+# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol', 'wep_encrypt',
 #           'passwd_index', 'wep_passwd', 'wpa_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid', 'hide_type']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))
 # router = Router(serial='1', band='5G', ssid='ASUSAX5400_5G', wireless_mode='N/AC mixed',

--- a/src/tools/router_tool/AsusRouter/Asusax6700Control.py
+++ b/src/tools/router_tool/AsusRouter/Asusax6700Control.py
@@ -101,14 +101,14 @@ class Asusax6700Control:
                             router.band]: raise ConfigError('bandwidth element error')
                 self.router_control.change_bandwidth(router.bandwidth)
 
-            # 修改 authentication
-            if router.authentication:
+            # 修改 security_protocol
+            if router.security_protocol:
                 auth_list = (self.AUTHENTICATION_METHOD
                              if router.wireless_mode != 'Legacy'
                              else self.AUTHENTICATION_METHOD_LEGCY)
-                if router.authentication not in auth_list:
-                    raise ConfigError('authentication method element error')
-                self.router_control.change_authentication(router.authentication)
+                if router.security_protocol not in auth_list:
+                    raise ConfigError('security protocol method element error')
+                self.router_control.change_authentication(router.security_protocol)
 
             # 修改 wep_encrypt
             if (router.wep_encrypt):
@@ -167,7 +167,7 @@ class Asusax6700Control:
             self.router_control.driver.quit()
 
 
-# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication', 'wep_encrypt',
+# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol', 'wep_encrypt',
 #           'passwd_index', 'wep_passwd', 'wpa_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid', 'hide_type']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))
 # router = Router(serial='1', band='5G', ssid='ASUSAX6700_5G', wireless_mode='Legacy',

--- a/src/tools/router_tool/AsusRouter/Asusax86uControl.py
+++ b/src/tools/router_tool/AsusRouter/Asusax86uControl.py
@@ -117,11 +117,11 @@ class Asusax86uControl(RouterTools):
                 # //*[@id="WLgeneral"]/tbody/tr[11]/td/select/option[22]
                 self.change_channel(channel)
 
-            # 修改 authentication
+            # 修改 security_protocol
             # //*[@id="WLgeneral"]/tbody/tr[13]/td/div[1]/select/option[1]
             # //*[@id="WLgeneral"]/tbody/tr[13]/td/div[1]/select/option[5]
-            if (router.authentication):
-                self.change_authentication(router.authentication)
+            if (router.security_protocol):
+                self.change_authentication(router.security_protocol)
 
             # 修改 wep_encrypt
             if (router.wep_encrypt):
@@ -169,7 +169,7 @@ class Asusax86uControl(RouterTools):
         finally:
             self.driver.quit()
 
-# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication', 'password', 'test_type',
+# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol', 'password', 'test_type',
 #           'wep_encrypt', 'passwd_index', 'wep_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid', 'wifi6']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))
 # router = Router(band='5G', ssid='ATC_ASUS_AX88U_5G', wireless_mode='AX only', channel='100', bandwidth='20 MHz',

--- a/src/tools/router_tool/AsusRouter/Asusax88uControl.py
+++ b/src/tools/router_tool/AsusRouter/Asusax88uControl.py
@@ -207,7 +207,7 @@ class Asusax88uControl(RouterTools):
         mode_list = self.AUTHENTICATION_METHOD if method != 'Legacy' \
             else self.AUTHENTICATION_METHOD_LEGCY
         if method not in mode_list:
-            raise ConfigError('authentication method element error')
+            raise ConfigError('security protocol method element error')
         self.telnet_write(cmd.format(self.MODE_PARAM[method]))
         if method == 'Open System':
             self.set_2g_wep_encrypt('None')
@@ -217,7 +217,7 @@ class Asusax88uControl(RouterTools):
         mode_list = self.AUTHENTICATION_METHOD if method != 'Legacy' \
             else self.AUTHENTICATION_METHOD_LEGCY
         if method not in mode_list:
-            raise ConfigError('authentication method element error')
+            raise ConfigError('security protocol method element error')
         self.telnet_write(cmd.format(self.MODE_PARAM[method]))
         if method == 'Open System':
             self.set_5g_wep_encrypt('None')
@@ -301,11 +301,11 @@ class Asusax88uControl(RouterTools):
             self.set_2g_password(router.password) if '2' in router.band else self.set_5g_password(
                 router.password)
 
-        # 修改 authentication
-        if router.authentication:
+        # 修改 security_protocol
+        if router.security_protocol:
             self.set_2g_authentication(
-                router.authentication) if '2' in router.band else self.set_5g_authentication(
-                router.authentication)
+                router.security_protocol) if '2' in router.band else self.set_5g_authentication(
+                router.security_protocol)
 
         # 修改channel
         if router.channel:
@@ -336,7 +336,7 @@ class Asusax88uControl(RouterTools):
 
 # ['Open System', 'WPA2-Personal', 'WPA3-Personal', 'WPA/WPA2-Personal', 'WPA2/WPA3-Personal',
 #                              'WPA2-Enterprise', 'WPA/WPA2-Enterprise']
-# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
 #           'password', 'test_type', 'protocol_type', 'wep_encrypt', 'wep_passwd',
 #           'hide_ssid', 'hide_type', 'wpa_encrypt', 'passwd_index', 'protect_frame',
 #           'smart_connect', 'country_code']

--- a/src/tools/router_tool/H3CBX54Control.py
+++ b/src/tools/router_tool/H3CBX54Control.py
@@ -150,15 +150,15 @@ class H3CBX54Control():
                 self.router_control.driver.find_element(
                     By.XPATH, target_element + '/option[1]').click()
 
-            # 修改 authentication
+            # 修改 security_protocol
             # //*[@id="WLgeneral"]/tbody/tr[13]/td/div[1]/select/option[1]
             # //*[@id="WLgeneral"]/tbody/tr[13]/td/div[1]/select/option[5]
             #
-            if (router.authentication):
+            if (router.security_protocol):
                 try:
-                    index = H3CRouterConfig.AUTHENTICATION_METHOD_DICT[router.authentication]
+                    index = H3CRouterConfig.AUTHENTICATION_METHOD_DICT[router.security_protocol]
                 except ConfigError:
-                    raise ConfigError('authentication method element error')
+                    raise ConfigError('security protocol method element error')
                 # //*[@id="ssid_enc"]/option[1]
                 self.router_control.change_authentication(index)
 
@@ -194,7 +194,7 @@ class H3CBX54Control():
 
 
 # fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth',
-#           'authentication', 'wpa_passwd', 'test_type', 'wep_encrypt',
+#           'security_protocol', 'wpa_passwd', 'test_type', 'wep_encrypt',
 #           'passwd_index', 'wep_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))
 # router = Router(serial='1', band='2.4G', ssid='H3CBX54_2.4G', wireless_mode='b+g+n', channel='8', bandwidth='20M',

--- a/src/tools/router_tool/Linksys1200acControl.py
+++ b/src/tools/router_tool/Linksys1200acControl.py
@@ -128,11 +128,11 @@ class Linksys1200acControl():
                         By.XPATH, self.router_control.xpath['ssid_element_5g']).send_keys(router.ssid)
 
             #
-            if (router.authentication):
+            if (router.security_protocol):
                 try:
-                    index = Linksys1200acConfig.AUTHENTICATION_METHOD_DICT[router.authentication]
+                    index = Linksys1200acConfig.AUTHENTICATION_METHOD_DICT[router.security_protocol]
                 except ConfigError:
-                    raise ConfigError('authentication method element error')
+                    raise ConfigError('security protocol method element error')
                 # //*[@id="ssid_enc"]/option[1]
                 if '2' in router.band:
                     target_element = 'authtication_2g'
@@ -244,7 +244,7 @@ class Linksys1200acControl():
         finally:
             self.router_control.driver.quit()
 
-# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
 #           'wpa_passwd', 'test_type', 'wep_encrypt', 'passwd_index', 'wep_passwd',
 #           'protect_frame', 'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))

--- a/src/tools/router_tool/NetgearR6100Control.py
+++ b/src/tools/router_tool/NetgearR6100Control.py
@@ -100,7 +100,7 @@ class NetgearR6100Control():
                         if router.wireless_mode != '54Mbps':
                             authentication_element = self.router_control.xpath['authentication_for_2G_element']
                             self.router_control.driver.find_element(By.XPATH, authentication_element[
-                                router.authentication]).click()
+                                router.security_protocol]).click()
                         mode_value = NetgearR6100Config.WIRELESS_MODE_2_DICT[router.wireless_mode]
                         mode_element = self.router_control.xpath['mode_select_element']['mode_for_2g']
                     else:
@@ -111,20 +111,20 @@ class NetgearR6100Control():
                 mode_select = Select(self.router_control.driver.find_element(By.XPATH, mode_element))
                 mode_select.select_by_value(mode_value)
             # # change authentication
-            if (router.authentication):
+            if (router.security_protocol):
                 try:
                     if router.band == '2.4G':
                         authentication_element = self.router_control.xpath['authentication_for_2G_element']
                     else:
                         authentication_element = self.router_control.xpath['authentication_for_5G_element']
                 except KeyError:
-                    raise ConfigError('authentication element error')
+                    raise ConfigError('security protocol element error')
                 if self.router_control.element_is_selected(authentication_element[
-                                                               router.authentication]):
+                                                               router.security_protocol]):
                     pass
                 else:
                     self.router_control.driver.find_element(By.XPATH, authentication_element[
-                        router.authentication]).click()
+                        router.security_protocol]).click()
             # set authentication_password
             if (router.wpa_passwd):
                 try:
@@ -177,7 +177,7 @@ class NetgearR6100Control():
 
 
 # fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth',
-#           'authentication', 'wpa_passwd', 'test_type', 'wep_encrypt',
+#           'security_protocol', 'wpa_passwd', 'test_type', 'wep_encrypt',
 #           'passwd_index', 'wep_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))
 # router = Router(serial='1', band='2.4G', ssid='NETGEAR_2G', wireless_mode='54Mbps', channel='AUTO',

--- a/src/tools/router_tool/Router.py
+++ b/src/tools/router_tool/Router.py
@@ -17,7 +17,7 @@ def _info(info):
 
 
 def router_str(self):
-    return f'{_info(self.band)},{_info(self.ssid)},{_info(self.wireless_mode)},{_info(self.channel)},{_info(self.bandwidth)},{_info(self.authentication)}'
+    return f'{_info(self.band)},{_info(self.ssid)},{_info(self.wireless_mode)},{_info(self.channel)},{_info(self.bandwidth)},{_info(self.security_protocol)}'
 
 
 RUN_SETTING_ACTIVITY = RouterConst.RUN_SETTING_ACTIVITY

--- a/src/tools/router_tool/Tplink/TplinkAx6000Control.py
+++ b/src/tools/router_tool/Tplink/TplinkAx6000Control.py
@@ -129,11 +129,11 @@ class TplinkAx6000Control:
                     By.ID, self.router_control.xpath['wpa_passwd'][target_element]).send_keys(router.wpa_passwd)
 
             time.sleep(2)
-            if (router.authentication):
+            if (router.security_protocol):
                 try:
-                    index = TplinkAx6000Config.AUTHENTICATION_METHOD_DICT[router.authentication]
+                    index = TplinkAx6000Config.AUTHENTICATION_METHOD_DICT[router.security_protocol]
                 except ConfigError:
-                    raise ConfigError('authentication method key error')
+                    raise ConfigError('security protocol method key error')
 
                 if '2' in router.band:
                     target_element = 'authtication_2g'
@@ -257,7 +257,7 @@ class TplinkAx6000Control:
             self.router_control.driver.quit()
 
 
-# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
 #           'wpa_passwd', 'test_type', 'wep_encrypt', 'passwd_index', 'wep_passwd', 'protect_frame',
 #           'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))

--- a/src/tools/router_tool/Tplink/TplinkWr842Control.py
+++ b/src/tools/router_tool/Tplink/TplinkWr842Control.py
@@ -159,15 +159,15 @@ class TplinkWr842Control:
             time.sleep(1)
             wait_for = self.router_control.driver.find_element(By.ID, "help")
             target_element = ''
-            if (router.authentication):
-                if router.authentication not in TplinkWr842Config.AUTHENTICATION_METHOD_LIST:
-                    raise ConfigError('authentication method key error')
+            if (router.security_protocol):
+                if router.security_protocol not in TplinkWr842Config.AUTHENTICATION_METHOD_LIST:
+                    raise ConfigError('security protocol method key error')
 
-                if router.authentication in 'WPA/WPA2':
+                if router.security_protocol in 'WPA/WPA2':
                     target_element = 'WPA/WPA2'
-                elif router.authentication in 'WPA-PSK/WPA2-PSK':
+                elif router.security_protocol in 'WPA-PSK/WPA2-PSK':
                     target_element = 'WPA-PSK/WPA2-PSK'
-                elif router.authentication == 'OPEN':
+                elif router.security_protocol == 'OPEN':
                     target_element = 'NONE'
                 else:
                     target_element = 'WEP'
@@ -176,16 +176,16 @@ class TplinkWr842Control:
                 self.router_control.driver.find_element(
                     By.XPATH, self.router_control.xpath['wr842_authentication_element'][target_element]).click()
                 if target_element != 'NONE':
-                    if router.authentication == 'WPA/WPA2' or router.authentication == 'WPA-PSK/WPA2-PSK':
-                        authentication = '自动'
+                    if router.security_protocol == 'WPA/WPA2' or router.security_protocol == 'WPA-PSK/WPA2-PSK':
+                        security_protocol = '自动'
                     else:
-                        authentication = router.authentication
+                        security_protocol = router.security_protocol
                     target_dict = {
                         'WPA/WPA2': TplinkWr842Config.WPA_DICT,
                         'WPA-PSK/WPA2-PSK': TplinkWr842Config.PSK_DICT,
                         'WEP': TplinkWr842Config.WEP_DICT
                     }
-                    index = target_dict[target_element][authentication]
+                    index = target_dict[target_element][security_protocol]
                     # /html/body/center/form/table/tbody/tr[2]/td/table/tbody/tr[1]/td[2]/table[8]/tbody/tr[2]/td[2]/select/option[1]
                     self.router_control.driver.find_element(
                         By.XPATH,
@@ -268,7 +268,7 @@ class TplinkWr842Control:
             self.router_control.driver.quit()
 
 
-# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
 #           'wpa_passwd', 'test_type', 'wep_encrypt', 'passwd_index', 'wep_passwd', 'protect_frame',
 #           'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))

--- a/src/tools/router_tool/Xiaomi/XiaomiBe7000Control.py
+++ b/src/tools/router_tool/Xiaomi/XiaomiBe7000Control.py
@@ -153,12 +153,12 @@ class XiaomiBe7000Control(RouterTools):
         else:
             if target.is_selected():
                 target.click()
-        # 修改 authentication
-        if router.authentication:
+        # 修改 security_protocol
+        if router.security_protocol:
             try:
-                index = self.AUTHENTICATION_METHOD[router.authentication]
+                index = self.AUTHENTICATION_METHOD[router.security_protocol]
             except ConfigError:
-                raise ConfigError('authentication method element error')
+                raise ConfigError('security protocol method element error')
             target = 'authentication_2g' if self.BAND_2 == router.band else 'authentication_5g'
             self.driver.find_element(
                 By.XPATH, self.xpath['authentication_select_element'][target]).click()

--- a/src/tools/router_tool/Xiaomi/Xiaomiax3600Control.py
+++ b/src/tools/router_tool/Xiaomi/Xiaomiax3600Control.py
@@ -159,12 +159,12 @@ class Xiaomiax3600Control(RouterTools):
         else:
             if target.is_selected():
                 target.click()
-        # 修改 authentication
-        if router.authentication:
+        # 修改 security_protocol
+        if router.security_protocol:
             try:
-                index = self.AUTHENTICATION_METHOD[router.authentication]
+                index = self.AUTHENTICATION_METHOD[router.security_protocol]
             except ConfigError:
-                raise ConfigError('authentication method element error')
+                raise ConfigError('security protocol method element error')
             target = 'authentication_2g' if self.BAND_2 == router.band else 'authentication_5g'
             self.driver.find_element(
                 By.XPATH, self.xpath['authentication_select_element'][target]).click()
@@ -261,7 +261,7 @@ class Xiaomiax3600Control(RouterTools):
         self.driver.quit()
         return True
 
-# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication', 'password',
+# fields = ['serial', 'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol', 'password',
 #           'test_type',
 #           'wep_encrypt', 'passwd_index', 'wep_passwd', 'protect_frame', 'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))

--- a/src/tools/router_tool/ZTEax5400Control.py
+++ b/src/tools/router_tool/ZTEax5400Control.py
@@ -82,12 +82,12 @@ class ZTEax5400Control():
             if not select.get_attribute('checked'):
                 element.click()
 
-        # 修改 authentication
-        if (router.authentication):
+        # 修改 security_protocol
+        if (router.security_protocol):
             try:
-                index = ZTEax5400Config.AUTHENTICATION_METHOD[router.authentication]
+                index = ZTEax5400Config.AUTHENTICATION_METHOD[router.security_protocol]
             except ConfigError:
-                raise ConfigError('authentication method element error')
+                raise ConfigError('security protocol method element error')
             # //*[@id="ssid_enc"]/option[1]
             if '2' in router.band:
                 target_element = 'authtication_2g'
@@ -190,7 +190,7 @@ class ZTEax5400Control():
         # finally:
         #     self.router_control.driver.quit()
 
-# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+# fields = ['band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
 #           'wpa_passwd', 'test_type', 'wep_encrypt', 'passwd_index', 'wep_passwd',
 #           'protect_frame', 'wpa_encrypt', 'hide_ssid']
 # Router = namedtuple('Router', fields, defaults=[None, ] * len(fields))

--- a/src/tools/router_tool/router_performance.py
+++ b/src/tools/router_tool/router_performance.py
@@ -52,15 +52,15 @@ class dut_standard(json_mixin):
     def set_expect(self, *args):
         """
         Supported signatures:
-        1) set_expect(chip, band, interface, mode, authentication, bandwidth, mimo, direction, expect_data)
-        2) set_expect(band, interface, mode, authentication, bandwidth, mimo, direction, expect_data)
+        1) set_expect(chip, band, interface, mode, security_protocol, bandwidth, mimo, direction, expect_data)
+        2) set_expect(band, interface, mode, security_protocol, bandwidth, mimo, direction, expect_data)
            -> falls back to chip='COMMON' for backward compatibility.
         """
         if len(args) == 9:
-            chip, band, interface, mode, authentication, bandwidth, mimo, direction, expect_data = args
+            chip, band, interface, mode, security_protocol, bandwidth, mimo, direction, expect_data = args
         elif len(args) == 8:
             chip = 'COMMON'
-            band, interface, mode, authentication, bandwidth, mimo, direction, expect_data = args
+            band, interface, mode, security_protocol, bandwidth, mimo, direction, expect_data = args
         else:
             raise TypeError("set_expect() expects 8 or 9 positional arguments.")
 
@@ -69,7 +69,7 @@ class dut_standard(json_mixin):
         band = str(band).upper()
         interface = str(interface).upper()
         mode = str(mode).upper()
-        authentication = str(authentication).upper()
+        security_protocol = str(security_protocol).upper()
         bandwidth_key = str(bandwidth).upper()
         mimo_key = str(mimo).upper()
         direction_key = str(direction).upper()
@@ -92,180 +92,180 @@ class dut_standard(json_mixin):
             raise ValueError(f"mimo must be one of: {valid_mimo}")
         if direction_key not in valid_direction:
             raise ValueError("direction must be UL or DL")
-        if authentication not in valid_auth:
-            raise ValueError("authentication must be one of: WPA3, WPA2, WEP, OPEN SYSTEM")
+        if security_protocol not in valid_auth:
+            raise ValueError("security_protocol must be one of: WPA3, WPA2, WEP, OPEN SYSTEM")
 
-        # new structure (chip dimension + authentication dimension)
-        self[chip][band][interface][mode][authentication][bandwidth_key][mimo_key][direction_key] = expect_data
+        # new structure (chip dimension + security_protocol dimension)
+        self[chip][band][interface][mode][security_protocol][bandwidth_key][mimo_key][direction_key] = expect_data
 
 
 a = compatibility_router()
 a.set_info("192.168.200.4", '2', 'ASUS', 'RT-AX88U Pro',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '7', 'Xiaomi', 'AX3000 RA80',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '1', 'Netgear', 'AX1800 RAX20',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '2', 'TP-LINK', 'TL-XDR6030yizhanban',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '8', 'ASUS', 'RT-AC1900P',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '6', 'Tenda', 'JD12LProxinhaozengqiangban',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '5', 'Tenda', 'BE6LPro',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '3', 'COMFAST', 'CF-WR633AX',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '6', 'TP-LINK', 'TL-7DR7230yizhanban',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '1', 'ZTE', 'ZXSLC SR7410',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '6', 'Huawei', 'AX3Pro WS7206',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '2', 'Huawei', 'XIHE-BE70',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '4', 'ZTE', 'ZXSLC SR6110',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '8', 'MERCURY', 'D126',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '3', 'HONOR', 'X4Pro HLB-600',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '4', 'H3C', 'NX30Pro',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '3', 'ThundeRobot', 'SR5301ZA',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '5', 'Xiaomi', 'BE3600 RD15',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '6', 'Xiaomi', 'R4A',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '7', 'Xiaomi', 'AX3000T RD03',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '7', 'TP-LINK', 'TL-XDR5410yizhanban',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '4', 'H3C', 'Magic NX54',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '1', 'TP-LINK', 'TL-WDR7660qianzhaoyizhanban',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.5", '8', 'ASUS', 'TX-AX6000',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '1', 'ASUS', 'XD4 Pro',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '4', 'NETGEAR', 'RAX50',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '3', 'NETGEAR', 'RAX70',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.4", '8', 'RuiJie', 'RG-EW1300G',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '7', 'RuiJie', 'X60',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '5', 'Netcore', 'LK-DS7587',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.6", '5', 'TP-LINK', 'TL-7DR3630yizhanban',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.3", '2', 'LINKSYS', 'E8450',
-           {'2.4G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 a.set_info("192.168.200.7", '1', 'ARRIS', 'TR4400',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '2', 'ARRIS', 'SBR-AC1200P',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '3', 'ARRIS', 'W21',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '4', 'HUAWEI', 'BE7',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '5', 'BAFFALO', 'WZR-1750DHP',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '7', 'HUAWEI', 'BE3 PRO',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.7", '8', 'ARRIS', 'TG3452',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'}})
 
 a.set_info("192.168.200.8", '1', 'VANTIVA', 'SDX62',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AX', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AX', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.8", '3', 'PORTAL', '2AFZUSAP102',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.set_info("192.168.200.8", '8', 'ARRIS', 'SBR-AC1750',
-           {'2.4G': {'mode': '11N', 'authentication': 'wpa2', 'bandwidth': '20MHz'},
-            '5G': {'mode': '11AC', 'authentication': 'wpa2', 'bandwidth': '80MHz'}})
+           {'2.4G': {'mode': '11N', 'security_protocol': 'wpa2', 'bandwidth': '20MHz'},
+            '5G': {'mode': '11AC', 'security_protocol': 'wpa2', 'bandwidth': '80MHz'}})
 
 a.save_expect()
 dut = dut_standard()
@@ -350,7 +350,7 @@ def handle_expectdata(router_info, band, direction, chip_info=None):
     根据路由器信息和芯片方案获取预期吞吐率
 
     Args:
-        router_info: 路由器信息字典，至少包含 band 对应的 mode、authentication、bandwidth
+        router_info: 路由器信息字典，至少包含 band 对应的 mode、security_protocol、bandwidth
         band: '2.4G' or '5G'
         direction: 'UL' or 'DL'
         chip_info: 如 'w2_sdio'
@@ -391,7 +391,7 @@ def handle_expectdata(router_info, band, direction, chip_info=None):
 
     mode = _normalize_mode(router_info.get(band, {}).get('mode', '11AX'))
     bandwidth = _normalize_bandwidth(router_info.get(band, {}).get('bandwidth', '80MHz'))
-    authentication = _normalize_auth(router_info.get(band, {}).get('authentication', 'WPA2'))
+    security_protocol = _normalize_auth(router_info.get(band, {}).get('security_protocol', 'WPA2'))
 
     chip_key, interface = chip_info.split('_')
     if chip_key in ('W1', 'W1U'):
@@ -416,7 +416,7 @@ def handle_expectdata(router_info, band, direction, chip_info=None):
     data = _get_default(data, band.upper())
     data = _get_default(data, interface)
     data = _get_default(data, mode)
-    data = _get_default(data, authentication)
+    data = _get_default(data, security_protocol)
     data = _get_default(data, bandwidth)
     data = _get_default(data, mimo_key)
     return _get_default(data, direction.upper())

--- a/src/tools/yamlTool.py
+++ b/src/tools/yamlTool.py
@@ -37,6 +37,6 @@ class yamlTool:
 # print(coco.get_note('router')['name'])
 # # asusac68u
 # print(coco.get_note('wifi'))
-# # [{'band': 'autotest2g', 'ssid': 12345678, 'wireless_mode': 'N only', 'channel': 1, 'bandwidth': '40 MHz', 'authentication': 'WPA2-Personal'}, {'band': 'autotest2g', 'ssid': 12345678, 'wireless_mode': 'N only', 'channel': 6, 'bandwidth': '40 MHz', 'authentication': 'WPA2-Personal'}]
+# # [{'band': 'autotest2g', 'ssid': 12345678, 'wireless_mode': 'N only', 'channel': 1, 'bandwidth': '40 MHz', 'security_protocol': 'WPA2-Personal'}, {'band': 'autotest2g', 'ssid': 12345678, 'wireless_mode': 'N only', 'channel': 6, 'bandwidth': '40 MHz', 'security_protocol': 'WPA2-Personal'}]
 # print(coco.get_note('wifi')[0]['band'])
 # # autotest2g

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -91,7 +91,7 @@ class RvrWifiConfigPage(CardWidget):
         self.auth_combo = ComboBox(form_box)
         self.auth_combo.addItems(getattr(self.router, "AUTHENTICATION_METHOD", []))
         self.auth_combo.setMinimumWidth(150)
-        form_layout.addRow("authentication", self.auth_combo)
+        form_layout.addRow("security_protocol", self.auth_combo)
         # 密码输入框，用于自动填充和测试流程引用
         self.passwd_edit = LineEdit(form_box)
         form_layout.addRow("password", self.passwd_edit)
@@ -214,7 +214,7 @@ class RvrWifiConfigPage(CardWidget):
             "wireless_mode",
             "channel",
             "bandwidth",
-            "authentication",
+            "security_protocol",
             "ssid",
             "password",
             "tx",
@@ -349,7 +349,7 @@ class RvrWifiConfigPage(CardWidget):
         self.table.setColumnCount(len(self.headers))
         self.table.setHorizontalHeaderLabels(self.headers)
         header = self.table.horizontalHeader()
-        idx = self.headers.index("authentication")
+        idx = self.headers.index("security_protocol")
         ssid = self.headers.index("ssid")
         header.setSectionResizeMode(idx, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(ssid, QHeaderView.ResizeToContents)
@@ -414,7 +414,7 @@ class RvrWifiConfigPage(CardWidget):
             with QSignalBlocker(self.bandwidth_combo):
                 self.bandwidth_combo.setCurrentText(data.get("bandwidth", ""))
             with QSignalBlocker(self.auth_combo):
-                self.auth_combo.setCurrentText(data.get("authentication", ""))
+                self.auth_combo.setCurrentText(data.get("security_protocol", ""))
             with QSignalBlocker(self.passwd_edit):
                 self._on_auth_changed(self.auth_combo.currentText())
             with QSignalBlocker(self.passwd_edit):
@@ -466,7 +466,7 @@ class RvrWifiConfigPage(CardWidget):
             "wireless_mode": self.wireless_combo.currentText(),
             "channel": self.channel_combo.currentText(),
             "bandwidth": self.bandwidth_combo.currentText(),
-            "authentication": self.auth_combo.currentText(),
+            "security_protocol": self.auth_combo.currentText(),
             # "ssid": ssid,
             "password": self.passwd_edit.text(),
             "data_row": self.data_row_edit.text(),
@@ -500,7 +500,7 @@ class RvrWifiConfigPage(CardWidget):
             "wireless_mode": self.wireless_combo.currentText(),
             "channel": self.channel_combo.currentText(),
             "bandwidth": self.bandwidth_combo.currentText(),
-            "authentication": self.auth_combo.currentText(),
+            "security_protocol": self.auth_combo.currentText(),
             "ssid": ssid,
             "password": self.passwd_edit.text(),
             "tx": "1" if self.tx_check.isChecked() else "0",

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -75,7 +75,7 @@ class RouterConst:
     """路由器相关常量"""
     RUN_SETTING_ACTIVITY: Final[str] = 'am start -n com.android.tv.settings/.MainSettings'
     fields: Final[list[str]] = [
-        'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'authentication',
+        'band', 'ssid', 'wireless_mode', 'channel', 'bandwidth', 'security_protocol',
         'password', 'tx', 'rx', 'data_row', 'expected_rate', 'wifi6', 'wep_encrypt',
         'hide_ssid', 'hide_type', 'wpa_encrypt', 'passwd_index', 'protect_frame',
         'smart_connect', 'country_code'


### PR DESCRIPTION
## Summary
- rename CSV headers and constants from `authentication` to `security_protocol`
- update router utilities and tests for new `security_protocol` field
- adjust UI and data handlers accordingly

## Testing
- `pytest -q` *(fails: Interrupted: 304 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e061066c832bb956ab50169af73d