### PR TITLE
refactor: use fixtures for RF and corner setup

### DIFF
--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -41,40 +41,43 @@ def setup_router(request):
         next(common, None)
 
 
-def test_rvr(setup):
-    connect_status, router_info, corner_step_list, corner_tool = setup
-    if not connect_status:
-        logging.info("Can't connect wifi ,input 0")
-        with open(pytest.testResult.detail_file, 'a') as f:
-            f.write("\n Can't connect wifi , skip this loop\n\n")
-        return
-
+@pytest.fixture(scope='function')
+def setup_corner(setup_router):
+    connect_status, router_info, corner_step_list, corner_tool = setup_router
     for corner_value in corner_step_list:
         logging.info(f'corner_value {corner_value}')
         logging.info('set corner value')
         value = corner_value[0] if isinstance(corner_value, tuple) else corner_value
         corner_tool.execute_turntable_cmd('rt', angle=value)
         logging.info(corner_tool.get_turntanle_current_angle())
+        yield connect_status, router_info, value, corner_tool
 
+
+def test_rvo(setup_corner):
+    connect_status, router_info, corner_set, corner_tool = setup_corner
+    if not connect_status:
+        logging.info("Can't connect wifi ,input 0")
         with open(pytest.testResult.detail_file, 'a') as f:
-            f.write('-' * 40 + '\n')
-            info, corner_set = '', ''
-            db_set = 0
-            info += 'db_set :  \n'
-            corner_set = corner_value[0] if isinstance(corner_value, tuple) else corner_value
-            info += 'corner_set : ' + str(corner_set) + '\n'
-            f.write(info)
+            f.write("\n Can't connect wifi , skip this loop\n\n")
+        return
 
-        rssi_num = pytest.dut.get_rssi()
-        logging.info('start test tx/rx')
-        logging.info(f'router_info: {router_info}')
-        if int(router_info.test_type):
-            logging.info(f'rssi : {rssi_num} ')
-            pytest.dut.get_tx_rate(router_info, 'TCP',
-                                   corner_tool=corner_tool,
-                                   db_set=db_set)
-        if int(router_info.test_type):
-            logging.info(f'rssi : {rssi_num}')
-            pytest.dut.get_rx_rate(router_info, 'TCP',
-                                   corner_tool=corner_tool,
-                                   db_set=db_set)
+    with open(pytest.testResult.detail_file, 'a') as f:
+        f.write('-' * 40 + '\n')
+        info, db_set = '', 0
+        info += 'db_set :  \n'
+        info += 'corner_set : ' + str(corner_set) + '\n'
+        f.write(info)
+
+    rssi_num = pytest.dut.get_rssi()
+    logging.info('start test tx/rx')
+    logging.info(f'router_info: {router_info}')
+    if int(router_info.test_type):
+        logging.info(f'rssi : {rssi_num} ')
+        pytest.dut.get_tx_rate(router_info, 'TCP',
+                               corner_tool=corner_tool,
+                               db_set=db_set)
+    if int(router_info.test_type):
+        logging.info(f'rssi : {rssi_num}')
+        pytest.dut.get_rx_rate(router_info, 'TCP',
+                               corner_tool=corner_tool,
+                               db_set=db_set)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -9,7 +9,6 @@ version    ：python 3.9
 Description：
 """
 
-import itertools
 import logging
 import time
 from src.test import get_testdata
@@ -28,20 +27,20 @@ test_data = get_testdata(router)
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
-    step_list = []
+    rf_step_list = []
+    corner_step_list = []
     rf_tool = None
     corner_tool = None
 
     def pre(cfg, _router):
-        nonlocal step_list, rf_tool, corner_tool
+        nonlocal rf_tool, rf_step_list, corner_tool, corner_step_list
         rf_tool, rf_step_list = init_rf(cfg)
         corner_tool, corner_step_list = init_corner(cfg)
-        step_list = list(itertools.product(corner_step_list, rf_step_list))
 
     common = common_setup(request, pre_setup=pre)
     connect_status, router_info, _, _ = next(common)
     try:
-        yield connect_status, router_info, step_list, rf_tool, corner_tool
+        yield connect_status, router_info, corner_step_list, corner_tool, rf_step_list, rf_tool
     finally:
         next(common, None)
         logging.info('Reset rf value')
@@ -50,38 +49,50 @@ def setup_router(request):
         time.sleep(10)
 
 
-def test_rvr(setup):
-    connect_status, router_info, step_list, rf_tool, corner_tool = setup
+@pytest.fixture(scope='function')
+def setup_corner(setup_router):
+    connect_status, router_info, corner_step_list, corner_tool, rf_step_list, rf_tool = setup_router
+    for corner_value in corner_step_list:
+        logging.info(f'corner_value {corner_value}')
+        logging.info('set corner value')
+        corner_set = corner_value[0] if isinstance(corner_value, tuple) else corner_value
+        corner_tool.execute_turntable_cmd('rt', angle=corner_set)
+        logging.info(corner_tool.get_turntanle_current_angle())
+        yield connect_status, router_info, corner_set, corner_tool, rf_step_list, rf_tool
+
+
+@pytest.fixture(scope='function')
+def setup_rf(setup_corner):
+    connect_status, router_info, corner_set, corner_tool, rf_step_list, rf_tool = setup_corner
+    for rf_value in rf_step_list:
+        logging.info(f'set rf value {rf_value}')
+        db_set = rf_value[1] if isinstance(rf_value, tuple) else rf_value
+        rf_tool.execute_rf_cmd(db_set)
+        logging.info(rf_tool.get_rf_current_value())
+        yield connect_status, router_info, corner_set, db_set, rf_tool, corner_tool
+
+
+def test_rvr_rvo(setup_rf):
+    connect_status, router_info, corner_set, db_set, rf_tool, corner_tool = setup_rf
     if not connect_status:
         logging.info("Can't connect wifi ,input 0")
         with open(pytest.testResult.detail_file, 'a') as f:
             f.write("\n Can't connect wifi , skip this loop\n\n")
         return
 
-    for rf_value in step_list:
-        logging.info(f'set rf value {rf_value}')
-        db_set = rf_value[1] if isinstance(rf_value, tuple) else rf_value
-        rf_tool.execute_rf_cmd(db_set)
-        logging.info(rf_tool.get_rf_current_value())
+    with open(pytest.testResult.detail_file, 'a') as f:
+        f.write('-' * 40 + '\n')
+        info = ''
+        info += 'db_set : ' + str(db_set) + '\n'
+        info += 'corner_set : ' + str(corner_set) + '\n'
+        f.write(info)
 
-        logging.info('set corner value')
-        corner_set = rf_value[0] if isinstance(rf_value, tuple) else rf_value
-        corner_tool.execute_turntable_cmd('rt', angle=corner_set)
-        logging.info(corner_tool.get_turntanle_current_angle())
-
-        with open(pytest.testResult.detail_file, 'a') as f:
-            f.write('-' * 40 + '\n')
-            info = ''
-            info += 'db_set : ' + str(db_set) + '\n'
-            info += 'corner_set : ' + str(corner_set) + '\n'
-            f.write(info)
-
-        pytest.dut.get_rssi()
-        logging.info('start test iperf')
-        logging.info(f'router_info: {router_info}')
-        if int(router_info.tx):
-            logging.info(f'rssi : {pytest.dut.rssi_num}')
-            pytest.dut.get_tx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
-        if int(router_info.rx):
-            logging.info(f'rssi : {pytest.dut.rssi_num}')
-            pytest.dut.get_rx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
+    pytest.dut.get_rssi()
+    logging.info('start test iperf')
+    logging.info(f'router_info: {router_info}')
+    if int(router_info.tx):
+        logging.info(f'rssi : {pytest.dut.rssi_num}')
+        pytest.dut.get_tx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)
+    if int(router_info.rx):
+        logging.info(f'rssi : {pytest.dut.rssi_num}')
+        pytest.dut.get_rx_rate(router_info, 'TCP', corner_tool=corner_tool, db_set=db_set)


### PR DESCRIPTION
## Summary
- refactor RF-only tests to configure attenuation via fixture
- add corner fixture and simplify RVO tests
- chain corner and RF fixtures in combined RVR/RVO tests

## Testing
- `pytest src/test/performance/test_wifi_rvr.py::test_rvr -q` *(fails: expected str, bytes or os.PathLike object, not NoneType)*
- `pytest src/test/performance/test_wifi_rvo.py::test_rvo -q` *(fails: expected str, bytes or os.PathLike object, not NoneType)*
- `pytest src/test/performance/test_wifi_rvr_rvo.py::test_rvr_rvo -q` *(fails: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68a477331e90832b9006fceeabc55721