### PR TITLE
refactor: convert common setup to fixture

### DIFF
--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -24,16 +24,18 @@ logging.info(f'router {router}')
 test_data = get_testdata(router)
 
 
-@pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data],autouse=True)
-def setup_router(request):
-    common = common_setup(request)
-    connect_status, router_info, _, _ = next(common)
-    try:
-        yield connect_status, router_info
-    finally:
-        next(common, None)
+@pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
+def router_info(request):
+    return request.param
 
-def test_rvr():
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_router(common_setup):
+    connect_status, router_info, _, _, _ = common_setup
+    return connect_status, router_info
+
+
+def test_rvr(setup_router):
     connect_status, router_info = setup_router
     if not connect_status:
         logging.info("Can't connect wifi ,input 0")

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -27,19 +27,22 @@ corner_step_list = [i for i in range(*cfg['corner_angle']['step'])][::45]
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
-def setup_router(request):
-    corner_tool = None
+def router_info(request):
+    return request.param
 
-    def pre(cfg, _router):
-        nonlocal corner_tool
+
+@pytest.fixture
+def pre_setup():
+    def _pre(cfg, _router):
         corner_tool, _ = init_corner(cfg)
+        return corner_tool
+    return _pre
 
-    common = common_setup(request, pre_setup=pre)
-    connect_status, router_info, _, _ = next(common)
-    try:
-        yield connect_status, router_info, corner_step_list, corner_tool
-    finally:
-        next(common, None)
+
+@pytest.fixture(scope='session')
+def setup_router(common_setup):
+    connect_status, router_info, _, _, corner_tool = common_setup
+    yield connect_status, router_info, corner_step_list, corner_tool
 
 
 @pytest.fixture(scope="function", params=corner_step_list)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -29,21 +29,26 @@ corner_step_list = [i for i in range(*cfg['corner_angle']['step'])][::45]
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
-def setup_router(request):
-    rf_tool = None
-    corner_tool = None
+def router_info(request):
+    return request.param
 
-    def pre(cfg, _router):
-        nonlocal rf_tool, corner_tool
+
+@pytest.fixture
+def pre_setup():
+    def _pre(cfg, _router):
         rf_tool, _ = init_rf(cfg)
         corner_tool, _ = init_corner(cfg)
+        return rf_tool, corner_tool
+    return _pre
 
-    common = common_setup(request, pre_setup=pre)
-    connect_status, router_info, _, _ = next(common)
+
+@pytest.fixture(scope='session')
+def setup_router(common_setup):
+    connect_status, router_info, _, _, tools = common_setup
+    rf_tool, corner_tool = tools
     try:
         yield connect_status, router_info, corner_step_list, corner_tool, rf_step_list, rf_tool
     finally:
-        next(common, None)
         logging.info('Reset rf value')
         rf_tool.execute_rf_cmd(0)
         logging.info(rf_tool.get_rf_current_value())


### PR DESCRIPTION
## Summary
- expose `common_setup` as a session-scoped pytest fixture
- refactor performance tests to consume `common_setup` via fixture dependency instead of manual generator calls

## Testing
- `pytest test/performance/test_wifi_rvr.py::test_rvr -vv --resultpath=/tmp` *(fails: No such file or directory: '/workspace/wifi_test/src/config/compatibility_router.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a5845d01e0832b8888068c48508307