### PR TITLE
refactor performance tests to use init_router

### DIFF
--- a/src/test/performance/__init__.py
+++ b/src/test/performance/__init__.py
@@ -51,6 +51,13 @@ def init_corner(cfg: dict):
     return corner_tool, corner_step_list
 
 
+def init_router(cfg: dict) -> Router:
+    """根据配置返回路由实例"""
+    router = get_router(cfg['router']['name'])
+    logging.info(f'router {router}')
+    return router
+
+
 def pre_setup(cfg: dict, router: Router) -> Any:
     """默认的前置设置示例，测试文件可覆盖"""
     return None

--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -13,22 +13,19 @@ import logging
 from src.test import get_testdata
 import pytest
 
-from src.tools.router_tool.router_factory import get_router
 from src.tools.config_loader import load_config
 
-from src.test.performance import common_setup
+from src.test.performance import common_setup, init_router
 
-router_name = load_config(refresh=True)['router']['name']
-router = get_router(router_name)
-logging.info(f'router {router}')
-test_data = get_testdata(router)
+cfg = load_config(refresh=True)
+test_data = get_testdata(init_router(cfg))
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
     router_info = request.param
     cfg = load_config(refresh=True)
-    router = get_router(cfg['router']['name'])
+    router = init_router(cfg)
     pre = getattr(request.module, 'pre_setup', None)
     extra = pre(cfg, router) if callable(pre) else None
     connect_status = common_setup(cfg, router, router_info)

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -13,16 +13,12 @@ import logging
 from src.test import get_testdata
 import pytest
 
-from src.tools.router_tool.router_factory import get_router
 from src.tools.config_loader import load_config
 
-from src.test.performance import common_setup, init_corner
+from src.test.performance import common_setup, init_corner, init_router
 
 cfg = load_config(refresh=True)
-router_name = cfg['router']['name']
-router = get_router(router_name)
-logging.info(f'router {router}')
-test_data = get_testdata(router)
+test_data = get_testdata(init_router(cfg))
 corner_step_list = [i for i in range(*cfg['corner_angle']['step'])][::45]
 
 
@@ -35,7 +31,7 @@ def pre_setup(cfg, _router):
 def setup_router(request):
     router_info = request.param
     cfg = load_config(refresh=True)
-    router = get_router(cfg['router']['name'])
+    router = init_router(cfg)
     pre = getattr(request.module, 'pre_setup', None)
     extra = pre(cfg, router) if callable(pre) else None
     connect_status = common_setup(cfg, router, router_info)

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -14,13 +14,12 @@ import time
 from src.test import get_testdata
 import pytest
 
-from src.tools.router_tool.router_factory import get_router
 from src.tools.config_loader import load_config
 
-from src.test.performance import common_setup, init_rf
+from src.test.performance import common_setup, init_rf, init_router
 
 cfg = load_config(refresh=True)
-test_data = get_testdata(get_router(cfg['router']['name']))
+test_data = get_testdata(init_router(cfg))
 rf_step_list = [i for i in range(*cfg['rf_solution']['step'])][::3]
 
 
@@ -33,7 +32,7 @@ def pre_setup(cfg, _router):
 def setup_router(request):
     router_info = request.param
     cfg = load_config(refresh=True)
-    router = get_router(cfg['router']['name'])
+    router = init_router(cfg)
     pre = getattr(request.module, 'pre_setup', None)
     extra = pre(cfg, router) if callable(pre) else None
     connect_status = common_setup(cfg, router, router_info)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -14,16 +14,12 @@ import time
 from src.test import get_testdata
 import pytest
 
-from src.tools.router_tool.router_factory import get_router
 from src.tools.config_loader import load_config
 
-from src.test.performance import common_setup, init_rf, init_corner
+from src.test.performance import common_setup, init_rf, init_corner, init_router
 
 cfg = load_config(refresh=True)
-router_name = cfg['router']['name']
-router = get_router(router_name)
-logging.info(f'router {router}')
-test_data = get_testdata(router)
+test_data = get_testdata(init_router(cfg))
 rf_step_list = [i for i in range(*cfg['rf_solution']['step'])][::3]
 corner_step_list = [i for i in range(*cfg['corner_angle']['step'])][::45]
 
@@ -38,7 +34,7 @@ def pre_setup(cfg, _router):
 def setup_router(request):
     router_info = request.param
     cfg = load_config(refresh=True)
-    router = get_router(cfg['router']['name'])
+    router = init_router(cfg)
     pre = getattr(request.module, 'pre_setup', None)
     extra = pre(cfg, router) if callable(pre) else None
     connect_status = common_setup(cfg, router, router_info)


### PR DESCRIPTION
## Summary
- add `init_router` helper to centralize router creation
- refactor performance tests to use `init_router` instead of `get_router`

## Testing
- `pytest src/test/performance -q` *(fails: expected str, bytes or os.PathLike object, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ad6960c832b82a6548ea6fbc2f4