### PR TITLE
重构性能测试初始化流程

### DIFF
--- a/src/test/performance/__init__.py
+++ b/src/test/performance/__init__.py
@@ -17,8 +17,9 @@ from src.tools.connect_tool.lab_device_controller import LabDeviceController
 from src.tools.rs_test import rs
 
 
-def init_rf(cfg: dict):
+def init_rf():
     """根据配置初始化射频衰减器"""
+    cfg = load_config(refresh=True)
     rf_solution = cfg['rf_solution']
     model = rf_solution['model']
     if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'XIN-YI']:
@@ -37,8 +38,9 @@ def init_rf(cfg: dict):
     return rf_tool, rf_step_list
 
 
-def init_corner(cfg: dict):
+def init_corner():
     """根据配置初始化转台"""
+    cfg = load_config(refresh=True)
     corner_ip = cfg['corner_angle']['ip_address']
     corner_tool = rs() if corner_ip == '192.168.5.11' else LabDeviceController(corner_ip)
     logging.info(f'corner_ip {corner_ip}')
@@ -51,19 +53,15 @@ def init_corner(cfg: dict):
     return corner_tool, corner_step_list
 
 
-def init_router(cfg: dict) -> Router:
+def init_router() -> Router:
     """根据配置返回路由实例"""
+    cfg = load_config(refresh=True)
     router = get_router(cfg['router']['name'])
     logging.info(f'router {router}')
     return router
 
 
-def pre_setup(cfg: dict, router: Router) -> Any:
-    """默认的前置设置示例，测试文件可覆盖"""
-    return None
-
-
-def common_setup(cfg: dict, router: Router, router_info: Router) -> bool:
+def common_setup(router: Router, router_info: Router) -> bool:
     """通用的性能测试前置步骤"""
     logging.info("router setup start")
 
@@ -122,6 +120,7 @@ def common_setup(cfg: dict, router: Router, router_info: Router) -> bool:
     logging.info(f'pc_ip:{pytest.dut.pc_ip}')
     logging.info('dut connected')
 
+    cfg = load_config(refresh=True)
     rvr_tool = cfg['rvr']['tool']
     if rvr_tool == 'ixchariot':
         script = (
@@ -134,3 +133,15 @@ def common_setup(cfg: dict, router: Router, router_info: Router) -> bool:
         time.sleep(3)
 
     return connect_status
+
+
+def get_rf_step_list():
+    cfg = load_config(refresh=True)
+    rf_solution = cfg['rf_solution']
+    return [i for i in range(*rf_solution['step'])][::3]
+
+
+def get_corner_step_list():
+    cfg = load_config(refresh=True)
+    corner_step = cfg['corner_angle']['step']
+    return [i for i in range(*corner_step)][::45]

--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -13,30 +13,24 @@ import logging
 from src.test import get_testdata
 import pytest
 
-from src.tools.config_loader import load_config
-
 from src.test.performance import common_setup, init_router
 
-cfg = load_config(refresh=True)
-test_data = get_testdata(init_router(cfg))
+test_data = get_testdata(init_router())
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
     router_info = request.param
-    cfg = load_config(refresh=True)
-    router = init_router(cfg)
-    pre = getattr(request.module, 'pre_setup', None)
-    extra = pre(cfg, router) if callable(pre) else None
-    connect_status = common_setup(cfg, router, router_info)
+    router = init_router()
+    connect_status = common_setup(router, router_info)
     try:
-        yield connect_status, router_info, None, extra
+        yield connect_status, router_info
     finally:
         pytest.dut.kill_iperf()
 
 
 def test_rvr(setup_router):
-    connect_status, router_info, _, _ = setup_router
+    connect_status, router_info = setup_router
     if not connect_status:
         logging.info("Can't connect wifi ,input 0")
         with open(pytest.testResult.detail_file, 'a') as f:

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -13,31 +13,25 @@ import logging
 from src.test import get_testdata
 import pytest
 
-from src.tools.config_loader import load_config
+from src.test.performance import (
+    common_setup,
+    get_corner_step_list,
+    init_corner,
+    init_router,
+)
 
-from src.test.performance import common_setup, init_corner, init_router
-
-cfg = load_config(refresh=True)
-test_data = get_testdata(init_router(cfg))
-corner_step_list = [i for i in range(*cfg['corner_angle']['step'])][::45]
-
-
-def pre_setup(cfg, _router):
-    corner_tool, _ = init_corner(cfg)
-    return corner_tool
+test_data = get_testdata(init_router())
+corner_step_list = get_corner_step_list()
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
     router_info = request.param
-    cfg = load_config(refresh=True)
-    router = init_router(cfg)
-    pre = getattr(request.module, 'pre_setup', None)
-    extra = pre(cfg, router) if callable(pre) else None
-    connect_status = common_setup(cfg, router, router_info)
-    step_list = corner_step_list
+    router = init_router()
+    corner_tool, step_list = init_corner()
+    connect_status = common_setup(router, router_info)
     try:
-        yield connect_status, router_info, step_list, extra
+        yield connect_status, router_info, step_list, corner_tool
     finally:
         pytest.dut.kill_iperf()
 

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -14,38 +14,31 @@ import time
 from src.test import get_testdata
 import pytest
 
-from src.tools.config_loader import load_config
+from src.test.performance import (
+    common_setup,
+    get_rf_step_list,
+    init_rf,
+    init_router,
+)
 
-from src.test.performance import common_setup, init_rf, init_router
-
-cfg = load_config(refresh=True)
-test_data = get_testdata(init_router(cfg))
-rf_step_list = [i for i in range(*cfg['rf_solution']['step'])][::3]
-
-
-def pre_setup(cfg, _router):
-    rf_tool, _ = init_rf(cfg)
-    return rf_tool
+test_data = get_testdata(init_router())
+rf_step_list = get_rf_step_list()
 
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
     router_info = request.param
-    cfg = load_config(refresh=True)
-    router = init_router(cfg)
-    pre = getattr(request.module, 'pre_setup', None)
-    extra = pre(cfg, router) if callable(pre) else None
-    connect_status = common_setup(cfg, router, router_info)
-    step_list = rf_step_list
+    router = init_router()
+    rf_tool, step_list = init_rf()
+    connect_status = common_setup(router, router_info)
     try:
-        yield connect_status, router_info, step_list, extra
+        yield connect_status, router_info, step_list, rf_tool
     finally:
         pytest.dut.kill_iperf()
-        if extra:
-            logging.info('Reset rf value')
-            extra.execute_rf_cmd(0)
-            logging.info(extra.get_rf_current_value())
-            time.sleep(10)
+        logging.info('Reset rf value')
+        rf_tool.execute_rf_cmd(0)
+        logging.info(rf_tool.get_rf_current_value())
+        time.sleep(10)
 
 
 @pytest.fixture(scope='function', params=rf_step_list)


### PR DESCRIPTION
## Summary
- 内部化加载配置，简化 init_router、init_rf、init_corner 以及通用设置
- 更新各性能测试脚本，移除 pre_setup 相关逻辑并使用新的初始化接口
- 精简 peak throughput 测试的路由器设置

## Testing
- `pytest src/test/performance/test_wifi_peak_throughput.py::test_rvr -q` *(失败：ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a660339fb0832ba3e689c3539d421d