### PR TITLE
feat: log fixture parameters and rename XIN-YI model

### DIFF
--- a/src/test/performance/__init__.py
+++ b/src/test/performance/__init__.py
@@ -22,9 +22,9 @@ def init_rf():
     cfg = load_config(refresh=True)
     rf_solution = cfg['rf_solution']
     model = rf_solution['model']
-    if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'XIN-YI']:
+    if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'RS232Board5']:
         raise EnvironmentError("Doesn't support this model")
-    if model == 'XIN-YI':
+    if model == 'RS232Board5':
         rf_tool = rs()
     else:
         rf_ip = rf_solution[model]['ip_address']

--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -10,6 +10,7 @@ Description：
 """
 
 import logging
+import json
 from src.test import get_testdata
 import pytest
 
@@ -20,6 +21,7 @@ test_data = get_testdata(init_router())
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_router', 'params': request.param})}", flush=True)
     router_info = request.param
     router = init_router()
     connect_status = common_setup(router, router_info)

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -10,6 +10,7 @@ Description：
 """
 
 import logging
+import json
 from src.test import get_testdata
 import pytest
 
@@ -26,6 +27,7 @@ corner_step_list = get_corner_step_list()
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_router', 'params': request.param})}", flush=True)
     router_info = request.param
     router = init_router()
     corner_tool, step_list = init_corner()
@@ -38,6 +40,7 @@ def setup_router(request):
 
 @pytest.fixture(scope="function", params=corner_step_list)
 def setup_corner(request, setup_router):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_corner', 'params': request.param})}", flush=True)
     value = request.param[0] if isinstance(request.param, tuple) else request.param
     corner_tool = setup_router[3]
     corner_tool.execute_turntable_cmd("rt", angle=value)

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -11,6 +11,7 @@ Description：
 
 import logging
 import time
+import json
 from src.test import get_testdata
 import pytest
 
@@ -27,6 +28,7 @@ rf_step_list = get_rf_step_list()
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_router', 'params': request.param})}", flush=True)
     router_info = request.param
     router = init_router()
     rf_tool, step_list = init_rf()
@@ -43,6 +45,7 @@ def setup_router(request):
 
 @pytest.fixture(scope='function', params=rf_step_list)
 def setup_rf(request, setup_router):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_rf', 'params': request.param})}", flush=True)
     db_set = request.param[1] if isinstance(request.param, tuple) else request.param
     rf_tool = setup_router[3]
     rf_tool.execute_rf_cmd(db_set)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -11,6 +11,7 @@ Description：
 
 import logging
 import time
+import json
 from src.test import get_testdata
 import pytest
 
@@ -30,6 +31,7 @@ corner_step_list = get_corner_step_list()
 
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_router', 'params': request.param})}", flush=True)
     router_info = request.param
     router = init_router()
     rf_tool, rf_list = init_rf()
@@ -49,6 +51,7 @@ def setup_router(request):
 
 @pytest.fixture(scope="function", params=corner_step_list)
 def setup_corner(request, setup_router):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_corner', 'params': request.param})}", flush=True)
     corner_set = request.param[0] if isinstance(request.param, tuple) else request.param
     rf_step_list = setup_router[2][1]
     rf_tool, corner_tool = setup_router[3]
@@ -65,6 +68,7 @@ def setup_corner(request, setup_router):
 
 @pytest.fixture(scope="function", params=rf_step_list)
 def setup_rf(request, setup_corner):
+    print(f"[PYQT_FIX]{json.dumps({'fixture': 'setup_rf', 'params': request.param})}", flush=True)
     db_set = request.param[1] if isinstance(request.param, tuple) else request.param
     connect_status, router_info, corner_set, corner_tool, _, rf_tool = setup_corner
     rf_tool.execute_rf_cmd(db_set)

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -338,10 +338,10 @@ class CaseConfigPage(CardWidget):
     def on_rf_model_changed(self, model_str):
         """
         切换rf_solution.model时，仅展示当前选项参数
-        现在只有XIN-YI，如果有别的model，添加隐藏/显示逻辑
+        现在只有RS232Board5，如果有别的model，添加隐藏/显示逻辑
         """
-        # 当前只有XIN-YI，后续有其它model可以加if-else
-        self.xin_group.setVisible(model_str == "XIN-YI")
+        # 当前只有RS232Board5，后续有其它model可以加if-else
+        self.xin_group.setVisible(model_str == "RS232Board5")
         self.rc4_group.setVisible(model_str == "RC4DAT-8G-95")
         self.rack_group.setVisible(model_str == "RADIORACK-4-220")
 
@@ -513,13 +513,13 @@ class CaseConfigPage(CardWidget):
                 vbox = QVBoxLayout(group)
                 # -------- 下拉：选择型号 --------
                 self.rf_model_combo = ComboBox(self)
-                self.rf_model_combo.addItems(["XIN-YI", "RC4DAT-8G-95", "RADIORACK-4-220"])
-                self.rf_model_combo.setCurrentText(value.get("model", "XIN-YI"))
+                self.rf_model_combo.addItems(["RS232Board5", "RC4DAT-8G-95", "RADIORACK-4-220"])
+                self.rf_model_combo.setCurrentText(value.get("model", "RS232Board5"))
                 self.rf_model_combo.currentTextChanged.connect(self.on_rf_model_changed)
                 vbox.addWidget(QLabel("Model:"))
                 vbox.addWidget(self.rf_model_combo)
 
-                # ========== ① XIN-YI 参数区（目前无额外字段，可放提醒文字） ==========
+                # ========== ① RS232Board5 参数区（目前无额外字段，可放提醒文字） ==========
                 self.xin_group = QWidget()
                 xin_box = QVBoxLayout(self.xin_group)
                 xin_box.addWidget(QLabel("SH - New Wi-Fi full-wave anechoic chamber "))


### PR DESCRIPTION
## Summary
- move json imports to module level for performance test fixtures
- log fixture parameters via JSON without per-function imports
- replace `XIN-YI` references with `RS232Board5`

## Testing
- `pytest src/test/performance/test_wifi_peak_throughput.py -vv -s --resultpath=/tmp` (fails: ModuleNotFoundError: No module named 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_68a6673d7a8c832bab305e297eec15fd