### PR TITLE
feat: log fixture parameters with decorator

### DIFF
--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -11,7 +11,7 @@ Description：
 
 import logging
 from src.test import get_testdata
-from src.test.pyqt_log import pyqt_log
+from src.test.pyqt_log import log_fixture_params
 import pytest
 
 from src.test.performance import common_setup, init_router
@@ -19,9 +19,9 @@ from src.test.performance import common_setup, init_router
 test_data = get_testdata(init_router())
 
 
+@log_fixture_params()
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
-    pyqt_log('FIX', 'setup_router', request.param)
     router_info = request.param
     router = init_router()
     connect_status = common_setup(router, router_info)

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -11,7 +11,7 @@ Description：
 
 import logging
 from src.test import get_testdata
-from src.test.pyqt_log import pyqt_log
+from src.test.pyqt_log import log_fixture_params
 import pytest
 
 from src.test.performance import (
@@ -25,9 +25,9 @@ test_data = get_testdata(init_router())
 corner_step_list = get_corner_step_list()
 
 
+@log_fixture_params()
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
-    pyqt_log('FIX', 'setup_router', request.param)
     router_info = request.param
     router = init_router()
     corner_tool, step_list = init_corner()
@@ -38,9 +38,9 @@ def setup_router(request):
         pytest.dut.kill_iperf()
 
 
+@log_fixture_params()
 @pytest.fixture(scope="function", params=corner_step_list)
 def setup_corner(request, setup_router):
-    pyqt_log('FIX', 'setup_corner', request.param)
     value = request.param[0] if isinstance(request.param, tuple) else request.param
     corner_tool = setup_router[3]
     corner_tool.execute_turntable_cmd("rt", angle=value)

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -12,7 +12,7 @@ Description：
 import logging
 import time
 from src.test import get_testdata
-from src.test.pyqt_log import pyqt_log
+from src.test.pyqt_log import log_fixture_params
 import pytest
 
 from src.test.performance import (
@@ -26,9 +26,9 @@ test_data = get_testdata(init_router())
 rf_step_list = get_rf_step_list()
 
 
+@log_fixture_params()
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
-    pyqt_log('FIX', 'setup_router', request.param)
     router_info = request.param
     router = init_router()
     rf_tool, step_list = init_rf()
@@ -43,9 +43,9 @@ def setup_router(request):
         time.sleep(10)
 
 
+@log_fixture_params()
 @pytest.fixture(scope='function', params=rf_step_list)
 def setup_rf(request, setup_router):
-    pyqt_log('FIX', 'setup_rf', request.param)
     db_set = request.param[1] if isinstance(request.param, tuple) else request.param
     rf_tool = setup_router[3]
     rf_tool.execute_rf_cmd(db_set)

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -12,7 +12,7 @@ Description：
 import logging
 import time
 from src.test import get_testdata
-from src.test.pyqt_log import pyqt_log
+from src.test.pyqt_log import log_fixture_params
 import pytest
 
 from src.test.performance import (
@@ -29,9 +29,9 @@ rf_step_list = get_rf_step_list()
 corner_step_list = get_corner_step_list()
 
 
+@log_fixture_params()
 @pytest.fixture(scope='session', params=test_data, ids=[str(i) for i in test_data])
 def setup_router(request):
-    pyqt_log('FIX', 'setup_router', request.param)
     router_info = request.param
     router = init_router()
     rf_tool, rf_list = init_rf()
@@ -49,9 +49,9 @@ def setup_router(request):
         time.sleep(10)
 
 
+@log_fixture_params()
 @pytest.fixture(scope="function", params=corner_step_list)
 def setup_corner(request, setup_router):
-    pyqt_log('FIX', 'setup_corner', request.param)
     corner_set = request.param[0] if isinstance(request.param, tuple) else request.param
     rf_step_list = setup_router[2][1]
     rf_tool, corner_tool = setup_router[3]
@@ -66,9 +66,9 @@ def setup_corner(request, setup_router):
     )
 
 
+@log_fixture_params()
 @pytest.fixture(scope="function", params=rf_step_list)
 def setup_rf(request, setup_corner):
-    pyqt_log('FIX', 'setup_rf', request.param)
     db_set = request.param[1] if isinstance(request.param, tuple) else request.param
     connect_status, router_info, corner_set, corner_tool, _, rf_tool = setup_corner
     rf_tool.execute_rf_cmd(db_set)

--- a/src/test/pyqt_log.py
+++ b/src/test/pyqt_log.py
@@ -1,4 +1,6 @@
 import json
+import functools
+import pytest
 
 
 def pyqt_log(tag: str, fixture: str, params):
@@ -9,3 +11,16 @@ def pyqt_log(tag: str, fixture: str, params):
             return repr(o)
     payload = json.dumps({"fixture": fixture, "params": params}, default=default, ensure_ascii=False)
     print(f"[PYQT_{tag}]{payload}", flush=True)
+
+
+def log_fixture_params(tag="FIX", name=None):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            request = kwargs.get("request") or args[0]
+            pyqt_log(tag, name or func.__name__, request.param)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- add `log_fixture_params` decorator to centralize PyQt logging
- apply decorator to performance fixtures

## Testing
- `pytest -q` *(fails: No such file or directory: 'pytest.log')*

------
https://chatgpt.com/codex/tasks/task_e_68a6708ee140832bad6dc46061b164fb