### PR TITLE
移除路由器2G/5G Wi-Fi配置字段

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,10 +24,6 @@ rf_solution:
 router:
   name: asusax88u
   address: 192.168.5.1
-  ssid_2g: asusax88u_2g
-  passwd_2g: '12345678'
-  ssid_5g: asusax88u_5g
-  passwd_5g: '12345678'
 rvr:
   iperf:
     path: ''


### PR DESCRIPTION
## Summary
- 删除router中2G/5G的SSID与密码配置，保留基础信息

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'pytest.log')*
- `python - <<'PY'
from src.tools.config_loader import load_config
cfg = load_config(refresh=True)
print('router keys:', cfg.get('router', {}).keys())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a80ea27b70832b9f31e11ee5379bd1