### PR TITLE
移除冗余ssid属性

### DIFF
--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -72,8 +72,6 @@ class RvrWifiConfigPage(CardWidget):
         addr = addr_edit.text() if addr_edit is not None else None
         self.router, self.router_name = self._load_router(router_name, addr)
         self.headers, self.rows = self._load_csv()
-        # 当前页面使用的路由器 SSID
-        self.ssid: str = ""
         # 标记是否处于数据加载阶段，用于屏蔽信号回调
         self._loading = False
         main_layout = QHBoxLayout(self)
@@ -194,12 +192,12 @@ class RvrWifiConfigPage(CardWidget):
 
     def set_router_credentials(self, ssid: str, passwd: str) -> None:
         """设置路由器凭据并自动填充密码输入框"""
-        self.ssid = ssid
+        self.ssid_edit.setText(ssid)
         self.passwd_edit.setText(passwd)
 
     def get_router_credentials(self) -> tuple[str, str]:
         """返回当前页面的路由器 SSID 和密码"""
-        return self.ssid, self.passwd_edit.text()
+        return self.ssid_edit.text(), self.passwd_edit.text()
 
     def _load_router(self, name: str | None = None, address: str | None = None):
         from src.tools.config_loader import load_config


### PR DESCRIPTION
## Summary
- 移除 RvrWifiConfigPage 中的临时 `self.ssid` 属性，直接使用输入框
- 更新 `set_router_credentials` / `get_router_credentials` 使用表单数据

## Testing
- `pytest -q` *(失败：FileNotFoundError: [Errno 2] No such file or directory: 'pytest.log')*

------
https://chatgpt.com/codex/tasks/task_e_68a80fc638e8832ba4b415d3b9e7dc80