### PR TITLE
refactor iperf log parsing

### DIFF
--- a/src/tools/connect_tool/dut.py
+++ b/src/tools/connect_tool/dut.py
@@ -226,33 +226,18 @@ class dut():
             while True:
                 line = tn.read_until(b'Mbits/sec').decode('gbk').strip()
                 self.iperf_log_list.append(line)
-                if '[SUM]' not in line and self.pair != 1:
-                    logging.info('?????')
-                    continue
+                result = self._parse_iperf_log(self.iperf_log_list)
                 if self.rssi_num > -60:
-                    if line.strip(): logging.info(f'line : {line.strip()}')
-                    data = re.findall('\s0\.0+-\s*3\d+\.\d*.*?(\d+\.*\d*)\s+Mbits/sec.*?', line.strip(), re.S)
-                    if data:
-                        result_list.append(float(data[0]))
+                    if result:
+                        with lock:
+                            self.rvr_result = result
                         break
                 else:
-                    if line.strip(): logging.info(f'line : {line.strip()}')
-                    data = re.findall(r'.*?\d+\.\d*-\s*\d+\.\d*.*?(\d+\.*\d*)\s+Mbits/sec.*?', line.strip(), re.S)
-                    if data:
-                        result_list.append(float(data[0]))
-                    if len(result_list) > 30:
+                    if len(self.iperf_log_list) > 30:
+                        with lock:
+                            self.rvr_result = result if result else None
                         break
-            if result_list:
-                logging.info(f'throughput result : {sum(result_list) / len(result_list)}')
-                # logging.info(f'{result_list}')
-                with lock:
-                    self.rvr_result = sum(result_list) / len(result_list)
-            else:
-                with lock:
-                    self.rvr_result = None
             logging.info('run thread done')
-
-        result_list = []
         if '-s' in command:
             self.iperf_log_list = []
         if '-s' in command:
@@ -333,25 +318,27 @@ class dut():
                 logging.info(f'client pc command: {command}')
                 subprocess.Popen(command.split())
 
-    def _get_logcat(self, lines):
+    def _parse_iperf_log(self, lines):
+        """解析 iperf 日志并计算吞吐量."""
         result_list = []
         for line in lines:
             if '[SUM]' not in line and self.pair != 1:
                 continue
-            if line.strip(): logging.info(f'line : {line.strip()}')
+            if line.strip():
+                logging.info(f'line : {line.strip()}')
             data = re.findall(r'.*?\d+\.\d*-\s*\d+\.\d*.*?(\d+\.*\d*)\s+Mbits/sec.*?', line.strip(), re.S)
             if data:
                 result_list.append(float(data[0]))
             data = re.findall('\s0\.0+-\s*3\d+\.\d*.*?(\d+\.*\d*)\s+Mbits/sec.*?', line.strip(), re.S)
             if data:
-                return round(float(data[0]), 1)
+                return float(data[0])
         if result_list:
             logging.info(f'throughput result : {sum(result_list) / len(result_list)}')
-            # logging.info(f'{result_list}')
-            result = sum(result_list) / len(result_list)
-        else:
-            result = 0
-        return round(result, 1)
+            return sum(result_list) / len(result_list)
+        return 0.0
+
+    def _get_logcat(self, lines):
+        return round(self._parse_iperf_log(lines), 1)
 
     def get_logcat(self):
         # pytest.dut.kill_iperf()


### PR DESCRIPTION
## Summary
- unify iperf log parsing via new `_parse_iperf_log`
- reuse shared parsing in telnet thread and logcat handler

## Testing
- `pytest` *(fails: module 'pytest' has no attribute 'testResult')*

------
https://chatgpt.com/codex/tasks/task_e_68b68dfe816c832baec96811096d479f