### PR TITLE
feat: apply theme to log dock

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ from src.ui.windows_case_config import CaseConfigPage
 from src.ui.rvr_wifi_config import RvrWifiConfigPage
 from src.ui.run import RunPage
 from qfluentwidgets import setTheme, Theme
+from src.ui.theme import apply_theme
 from PyQt5.QtGui import QGuiApplication, QFont
 from PyQt5.QtCore import (
     QCoreApplication,
@@ -97,6 +98,8 @@ class LogDock(QDockWidget):
         self.editor.setReadOnly(True)
         self.setWidget(self.editor)
         self._reader: LogReader | None = None
+        apply_theme(self)
+        apply_theme(self.editor, recursive=True)
 
     def start_read(self, log_dir: str):
         if self._reader:


### PR DESCRIPTION
## Summary
- import and apply global theme to LogDock widget and its editor

## Testing
- `python -m pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'pytest.log')*

------
https://chatgpt.com/codex/tasks/task_e_68c0e62d28c4832b80ad96a8a7cf9f96