### PR TITLE
fix: standardize wireless options

### DIFF
--- a/src/test/__init__.py
+++ b/src/test/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from src.tools.router_tool.Router import Router
 from src.tools.config_loader import load_config
-from src.util.constants import get_config_base
+from src.util.constants import get_config_base, RouterConst
 
 
 def get_testdata(router):
@@ -45,6 +45,7 @@ def get_testdata(router):
             f"CSV file not found at {csv_path}. Please check router name '{router_name}'."
         )
     ssid_verify = set()
+    default_wireless = RouterConst.DEFAULT_WIRELESS_MODES
 
     # 校验 csv 数据是否异常
     for i in test_data:
@@ -57,9 +58,7 @@ def get_testdata(router):
         if "5" in i.band:
             assert i.ssid not in ssid_verify, "5g ssid can't as the same as 2g , pls modify"
         assert i.band in ["2.4G", "5G"], "Pls check band info "
-        assert i.wireless_mode in {"2.4G": router.WIRELESS_2, "5G": router.WIRELESS_5}[
-            i.band
-        ], "Pls check wireless info"
+        assert i.wireless_mode in default_wireless[i.band], "Pls check wireless info"
         assert i.channel in {"2.4G": router.CHANNEL_2, "5G": router.CHANNEL_5}[
             i.band
         ], "Pls check channel info"

--- a/src/ui/rvr_wifi_config.py
+++ b/src/ui/rvr_wifi_config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import logging
 from contextlib import ExitStack
 from PyQt5.QtCore import Qt, QSignalBlocker
-from src.util.constants import Paths
+from src.util.constants import Paths, RouterConst
 from PyQt5.QtWidgets import (
     QHBoxLayout,
     QTableWidgetItem,
@@ -315,10 +315,7 @@ class RvrWifiConfigPage(CardWidget):
             self._loading = False
 
     def _update_band_options(self, band: str):
-        wireless = {
-            "2.4G": getattr(self.router, "WIRELESS_2", []),
-            "5G": getattr(self.router, "WIRELESS_5", []),
-        }[band]
+        wireless = RouterConst.DEFAULT_WIRELESS_MODES[band]
         channel = {
             "2.4G": getattr(self.router, "CHANNEL_2", []),
             "5G": getattr(self.router, "CHANNEL_5", []),

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -89,6 +89,10 @@ class RouterConst:
     }
     INTERFACE_CONFIG = ['SDIO','PCIE','USB']
     dut_wifichip: Final[str] = 'w2_sdio'
+    DEFAULT_WIRELESS_MODES: Final[dict[str, list[str]]] = {
+        "2.4G": ["auto", "11n", "11b", "11g", "11a", "11ac", "11ax"],
+        "5G": ["11ac", "11ax"],
+    }
 
 
 class RokuConst:


### PR DESCRIPTION
## Summary
- 将无线模式选项集中到 RouterConst.DEFAULT_WIRELESS_MODES
- UI 和测试引用共享常量，避免各品牌差异

## Testing
- `pytest` *(失败：FileNotFoundError: [Errno 2] No such file or directory: 'pytest.log')*

------
https://chatgpt.com/codex/tasks/task_e_68c40c695804832b8cf2fc0d72d3ebbf