### PR TITLE
Add DUT connectivity check after RF attenuation adjustments

### DIFF
--- a/src/test/performance/__init__.py
+++ b/src/test/performance/__init__.py
@@ -6,7 +6,7 @@
 import logging
 import re
 import time
-from typing import Any
+from typing import Any, Tuple
 from functools import lru_cache
 
 import pytest
@@ -132,6 +132,69 @@ def common_setup(router: Router, router_info: Router) -> bool:
         time.sleep(3)
 
     return connect_status
+
+
+def wait_for_dut_connection_recover(timeout: int = 120, interval: int = 5) -> Tuple[bool, str]:
+    """等待 DUT 在调整射频衰减后恢复网络连通性。
+
+    Args:
+        timeout: 最大等待时间（秒）。
+        interval: 每次检测之间的间隔时间（秒）。
+
+    Returns:
+        Tuple[bool, str]: (是否成功恢复, 恢复后的 IP 地址)。
+    """
+
+    logging.info('Check DUT connectivity after changing RF attenuation')
+    start_time = time.time()
+    last_error = ''
+    target_prefix = ''
+
+    if pytest.connect_type != 'telnet':
+        try:
+            target_prefix = re.findall(r'(\d+\.\d+\.\d+\.)', pytest.dut.pc_ip)[0]
+        except Exception as err:
+            logging.warning(f'Parse PC IP failed: {err}')
+
+    while time.time() - start_time < timeout:
+        try:
+            if pytest.connect_type != 'telnet':
+                try:
+                    ifconfig_info = pytest.dut.checkoutput('ifconfig wlan0')
+                    logging.info(f'ifconfig wlan0 info:\n{ifconfig_info}')
+                except Exception as info_err:
+                    logging.info(f'Check ifconfig wlan0 failed: {info_err}')
+
+            connected, ip_address = pytest.dut.wait_for_wifi_address(target=target_prefix)
+
+            if connected and ip_address and ip_address != '0.0.0.0':
+                logging.info(f'DUT network recovered, ip: {ip_address}')
+
+                if pytest.connect_type != 'telnet':
+                    try:
+                        ping_cmd = f'ping -c 1 -W 1 {pytest.dut.pc_ip}'
+                        ping_result = pytest.dut.checkoutput(ping_cmd)
+                        logging.info(f'ping result:\n{ping_result}')
+                    except Exception as ping_err:
+                        logging.warning(f'Ping verification failed: {ping_err}')
+
+                return True, ip_address
+
+        except AssertionError as err:
+            last_error = str(err)
+            logging.info(f'wait_for_wifi_address failed: {err}')
+        except Exception as err:
+            last_error = str(err)
+            logging.info(f'Connectivity check error: {err}')
+
+        time.sleep(interval)
+
+    if last_error:
+        logging.error(f'DUT connectivity did not recover after RF command: {last_error}')
+    else:
+        logging.error('DUT connectivity did not recover after RF command')
+
+    return False, ''
 
 
 @lru_cache(maxsize=1)

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -20,6 +20,7 @@ from src.test.performance import (
     get_rf_step_list,
     init_rf,
     init_router,
+    wait_for_dut_connection_recover,
 )
 
 _test_data = get_testdata(init_router())
@@ -46,6 +47,9 @@ def setup_attenuation(request, setup_router):
     db_set = request.param
     connect_status, router_info = setup_router
     rf_tool.execute_rf_cmd(db_set)
+    if connect_status:
+        recover_status, _ = wait_for_dut_connection_recover()
+        connect_status = connect_status and recover_status
     yield (connect_status, router_info, db_set)
     pytest.dut.kill_iperf()
 

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -22,6 +22,7 @@ from src.test.performance import (
     init_corner,
     init_rf,
     init_router,
+    wait_for_dut_connection_recover,
 )
 
 _test_data = get_testdata(init_router())
@@ -61,6 +62,9 @@ def setup_attenuation(request, setup_corner):
     db_set = request.param
     connect_status, router_info, corner_set = setup_corner
     rf_tool.execute_rf_cmd(db_set)
+    if connect_status:
+        recover_status, _ = wait_for_dut_connection_recover()
+        connect_status = connect_status and recover_status
     yield (connect_status, router_info, corner_set, db_set)
     pytest.dut.kill_iperf()
 


### PR DESCRIPTION
## Summary
- add a helper that waits for DUT connectivity recovery after RF attenuation changes using ifconfig/ping feedback
- invoke the helper in Wi-Fi RVR fixtures so throughput tests only continue after the DUT regains an IP address

## Testing
- pytest --collect-only -k rvr *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68c90e452a7c832baa7a4231891fbbfa