### PR TITLE
Improve iperf log wait condition

### DIFF
--- a/src/tools/connect_tool/dut.py
+++ b/src/tools/connect_tool/dut.py
@@ -351,9 +351,13 @@ class dut():
         deadline = time.time() + timeout
         while time.time() < deadline:
             with self._iperf_log_lock:
-                if self.iperf_log_list:
-                    return True
+                logs = list(self.iperf_log_list)
+            logging.debug('iperf logs len=%d', len(logs))
+            if logs and any(('Mbits/sec' in line) or ('[SUM]' in line) for line in logs):
+                logging.debug('iperf throughput keywords detected in logs')
+                return True
             time.sleep(interval)
+        logging.debug('wait for iperf logs timeout after %.1fs', timeout)
         return False
 
     def _parse_iperf_log(self, lines):


### PR DESCRIPTION
## Summary
- refine `_wait_for_iperf_logs` to wait until throughput indicators like `Mbits/sec` or `[SUM]` appear in collected iperf logs
- add debug logs to trace iperf log accumulation and timeout behaviour

## Testing
- `python - <<'PY' ...` (simulate iperf log production to verify waiting and parsing)


------
https://chatgpt.com/codex/tasks/task_e_68ccab45fa48832bab37c19109c4f312