### PR TITLE
调整RSSI调节方向与0dB退出逻辑

### DIFF
--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -89,7 +89,12 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
             break
 
         current_diff_sign = previous_diff_sign
-        direction = -1 if diff < 0 else 1
+        if diff < -tolerance:
+            direction = -1
+        elif diff > tolerance:
+            direction = 1
+        else:
+            break
         next_db = applied_db + direction * step
         next_db = max(0, min(110, next_db))
         no_adjustment_possible = next_db == applied_db
@@ -115,6 +120,12 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
         if abs(diff) <= tolerance:
             previous_diff_sign = new_diff_sign
             break
+        if diff < -tolerance:
+            direction = -1
+        elif diff > tolerance:
+            direction = 1
+        else:
+            break
         if (
             current_diff_sign != 0
             and new_diff_sign != 0
@@ -123,9 +134,9 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
             overshoot_detected = True
         previous_diff_sign = new_diff_sign
 
-        if applied_db == 0 and current_rssi < target_rssi - tolerance:
+        if applied_db == 0 and direction == 1 and no_adjustment_possible:
             logging.info(
-                'Attenuation already at 0 dB but RSSI %s dBm below target %s dBm, continue test.',
+                'Attenuation already at 0 dB but RSSI %s dBm above target %s dBm, continue test.',
                 current_rssi,
                 target_rssi,
             )


### PR DESCRIPTION
## Summary
- 依据 RSSI 与目标值的差异（含容差）重新判定衰减增减方向，修正 direction 的设定
- 调整 0dB 退出判断，仅在无法再减衰并且目标 RSSI 低于当前值时提前结束，并更新提示日志
- 保持 overshoot 处理逻辑，可在方向切换后继续按照减半步进收敛

## Testing
- python -m compileall src/test/performance/test_wifi_rvo.py

------
https://chatgpt.com/codex/tasks/task_e_68d26035224c832b895cfd07bdda4643