### PR TITLE
Fix RVO attenuation direction when raising target RSSI

### DIFF
--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -90,9 +90,9 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
 
         current_diff_sign = previous_diff_sign
         if diff < -tolerance:
-            direction = -1
-        elif diff > tolerance:
             direction = 1
+        elif diff > tolerance:
+            direction = -1
         else:
             break
         next_db = applied_db + direction * step
@@ -121,9 +121,9 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
             previous_diff_sign = new_diff_sign
             break
         if diff < -tolerance:
-            direction = -1
-        elif diff > tolerance:
             direction = 1
+        elif diff > tolerance:
+            direction = -1
         else:
             break
         if (
@@ -134,7 +134,7 @@ def _adjust_rssi_to_target(target_rssi: int, base_db: Optional[int]) -> Tuple[in
             overshoot_detected = True
         previous_diff_sign = new_diff_sign
 
-        if applied_db == 0 and direction == 1 and no_adjustment_possible:
+        if applied_db == 0 and direction == -1 and no_adjustment_possible:
             logging.info(
                 'Attenuation already at 0 dB but RSSI %s dBm above target %s dBm, continue test.',
                 current_rssi,


### PR DESCRIPTION
## Summary
- adjust `_adjust_rssi_to_target` so higher target RSSI values drive attenuation increases instead of forcing 0 dB
- keep the 0 dB early exit only for cases where further attenuation reduction is impossible

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68d2519ead74832bb6b7947e5e90116b