### PR TITLE
feat: support LDA-908V-8 attenuator

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,6 +22,8 @@ rf_solution:
     idProduct: '35'
     idVendor: '8398'
     ip_address: 192.168.5.75
+  LDA-908V-8:
+    ip_address: 192.168.5.200
   model: RC4DAT-8G-95
   step:
   - 0

--- a/src/test/performance/__init__.py
+++ b/src/test/performance/__init__.py
@@ -29,7 +29,7 @@ def init_rf():
     cfg = get_cfg()
     rf_solution = cfg['rf_solution']
     model = rf_solution['model']
-    if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'RS232Board5']:
+    if model not in ['RADIORACK-4-220', 'RC4DAT-8G-95', 'RS232Board5', 'LDA-908V-8']:
         raise EnvironmentError("Doesn't support this model")
     if model == 'RS232Board5':
         rf_tool = rs()

--- a/src/tools/connect_tool/lab_device_controller.py
+++ b/src/tools/connect_tool/lab_device_controller.py
@@ -11,6 +11,10 @@ import logging
 import re
 import time
 import telnetlib
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
 import pytest
 
 
@@ -19,6 +23,11 @@ class LabDeviceController:
     def __init__(self, ip):
         self.ip = ip
         self.model = pytest.config['rf_solution']['model']
+        self._last_set_value = None
+        self.tn = None
+        if self.model == 'LDA-908V-8':
+            logging.info(f'Initialize HTTP attenuator controller {self.model} at {ip}')
+            return
         try:
             logging.info(f'Try to connect {ip}')
             self.tn = telnetlib.Telnet()
@@ -45,23 +54,54 @@ class LabDeviceController:
         if int(value) < 0 or int(value) > 110:
             assert 0, 'value must be in range 1-110'
         logging.info(f'Set rf value to {value}')
-        if self.model == 'RC4DAT-8G-95':
+        if self.model == 'LDA-908V-8':
+            self._last_set_value = int(value)
+            params = {'chnl': 1, 'attn': self._last_set_value}
+            self._send_http_request('setup.cgi', params)
+        elif self.model == 'RC4DAT-8G-95':
             self.tn.write(f":CHAN:1:2:3:4:SETATT:{value};".encode('ascii') + b'\r\n')
             self.tn.read_some()
         else:
+            if not self.tn:
+                raise RuntimeError('Telnet connection not initialized')
             self.tn.write(f"ATT 1 {value};2 {value};3 {value};4 {value};".encode('ascii') + b'\r')
         time.sleep(2)
 
     def get_rf_current_value(self):
+        if self.model == 'LDA-908V-8':
+            params = {'chnl': 1}
+            if self._last_set_value is not None:
+                params['attn'] = self._last_set_value
+            response = self._send_http_request('status.shtm', params)
+            if response is None:
+                return None
+            match = re.search(r'(\d+)', response)
+            return int(match.group(1)) if match else response
         if self.model == 'RC4DAT-8G-95':
             self.tn.write("ATT?;".encode('ascii') + b'\r')
             # self.tn.read_some().decode('ascii')
             res = self.tn.read_some().decode('ascii')
             return res.split()[0]
         else:
+            if not self.tn:
+                raise RuntimeError('Telnet connection not initialized')
             self.tn.write("ATT".encode('ascii') + b'\r\n')
             res = self.tn.read_some().decode('utf-8')
             return list(map(int, re.findall(r'\s(\d+);', res)))
+
+    def _send_http_request(self, endpoint, params):
+        url = f"http://{self.ip}/{endpoint}"
+        query = urlencode(params)
+        full_url = f"{url}?{query}" if query else url
+        logging.info('Send HTTP request to %s', full_url)
+        try:
+            with urlopen(full_url, timeout=5) as resp:
+                content = resp.read().decode('utf-8', errors='ignore')
+                logging.debug('Response from %s: %s', endpoint, content)
+                return content
+        except URLError as exc:
+            logging.error('Failed to request %s: %s', full_url, exc)
+            raise
 
     def execute_turntable_cmd(self, type, angle=''):
         if type not in ['gs', 'rt', 'gcp']:

--- a/src/ui/windows_case_config.py
+++ b/src/ui/windows_case_config.py
@@ -346,9 +346,14 @@ class CaseConfigPage(CardWidget):
         现在只有RS232Board5，如果有别的model，添加隐藏/显示逻辑
         """
         # 当前只有RS232Board5，后续有其它model可以加if-else
-        self.xin_group.setVisible(model_str == "RS232Board5")
-        self.rc4_group.setVisible(model_str == "RC4DAT-8G-95")
-        self.rack_group.setVisible(model_str == "RADIORACK-4-220")
+        if hasattr(self, "xin_group"):
+            self.xin_group.setVisible(model_str == "RS232Board5")
+        if hasattr(self, "rc4_group"):
+            self.rc4_group.setVisible(model_str == "RC4DAT-8G-95")
+        if hasattr(self, "rack_group"):
+            self.rack_group.setVisible(model_str == "RADIORACK-4-220")
+        if hasattr(self, "lda_group"):
+            self.lda_group.setVisible(model_str == "LDA-908V-8")
         self._rebalance_columns()
         QTimer.singleShot(0, self._rebalance_columns)
 
@@ -633,7 +638,12 @@ class CaseConfigPage(CardWidget):
                 vbox = QVBoxLayout(group)
                 # -------- 下拉：选择型号 --------
                 self.rf_model_combo = ComboBox(self)
-                self.rf_model_combo.addItems(["RS232Board5", "RC4DAT-8G-95", "RADIORACK-4-220"])
+                self.rf_model_combo.addItems([
+                    "RS232Board5",
+                    "RC4DAT-8G-95",
+                    "RADIORACK-4-220",
+                    "LDA-908V-8",
+                ])
                 self.rf_model_combo.setCurrentText(value.get("model", "RS232Board5"))
                 self.rf_model_combo.currentTextChanged.connect(self.on_rf_model_changed)
                 vbox.addWidget(QLabel("Model:"))
@@ -677,6 +687,17 @@ class CaseConfigPage(CardWidget):
                 rack_box.addWidget(self.rack_ip_edit)
                 vbox.addWidget(self.rack_group)
 
+                # ========== ④ LDA-908V-8 参数区 ==========
+                self.lda_group = QWidget()
+                lda_box = QVBoxLayout(self.lda_group)
+                lda_cfg = value.get("LDA-908V-8", {})
+                self.lda_ip_edit = LineEdit(self)
+                self.lda_ip_edit.setPlaceholderText("ip_address")
+                self.lda_ip_edit.setText(lda_cfg.get("ip_address", ""))
+                lda_box.addWidget(QLabel("IP address :"))
+                lda_box.addWidget(self.lda_ip_edit)
+                vbox.addWidget(self.lda_group)
+
                 # -------- 通用字段：step --------
                 self.rf_step_edit = LineEdit(self)
                 self.rf_step_edit.setPlaceholderText("rf step; such as  0,50")
@@ -694,6 +715,7 @@ class CaseConfigPage(CardWidget):
                 self.field_widgets["rf_solution.RC4DAT-8G-95.idProduct"] = self.rc4_product_edit
                 self.field_widgets["rf_solution.RC4DAT-8G-95.ip_address"] = self.rc4_ip_edit
                 self.field_widgets["rf_solution.RADIORACK-4-220.ip_address"] = self.rack_ip_edit
+                self.field_widgets["rf_solution.LDA-908V-8.ip_address"] = self.lda_ip_edit
                 self.field_widgets["rf_solution.step"] = self.rf_step_edit
                 continue  # 跳过后面的通用字段处理
             if key == "rvr":
@@ -1037,6 +1059,7 @@ class CaseConfigPage(CardWidget):
                 "rf_solution.RC4DAT-8G-95.idProduct",
                 "rf_solution.RC4DAT-8G-95.ip_address",
                 "rf_solution.RADIORACK-4-220.ip_address",
+                "rf_solution.LDA-908V-8.ip_address",
             }
         # 如果你需要所有字段都可编辑，直接 return EditableInfo(set(self.field_widgets.keys()), True, True)
         return info


### PR DESCRIPTION
## Summary
- extend the attenuator configuration to include the new LDA-908V-8 option
- expose LDA-908V-8 controls in the case configuration UI with an IP address field and proper edit permissions
- add HTTP-based control logic for the LDA-908V-8 attenuator and allow it in rf initialization

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d4e47267c0832bb34178e92335ca0f