### PR TITLE
feat: support multi-port LDA-908V-8 configuration

### DIFF
--- a/src/tools/connect_tool/lab_device_controller.py
+++ b/src/tools/connect_tool/lab_device_controller.py
@@ -24,9 +24,22 @@ class LabDeviceController:
         self.ip = ip
         self.model = pytest.config['rf_solution']['model']
         self._last_set_value = None
+        self._lda_ports = {1}
+        self._last_used_ports = None
         self.tn = None
         if self.model == 'LDA-908V-8':
-            logging.info(f'Initialize HTTP attenuator controller {self.model} at {ip}')
+            lda_config = pytest.config['rf_solution'].get('LDA-908V-8', {})
+            try:
+                self._lda_ports = self._parse_port_config(lda_config.get('ports'))
+            except Exception as exc:
+                logging.error('Invalid LDA-908V-8 ports configuration: %s', exc)
+                raise
+            logging.info(
+                'Initialize HTTP attenuator controller %s at %s with ports %s',
+                self.model,
+                ip,
+                sorted(self._lda_ports),
+            )
             return
         try:
             logging.info(f'Try to connect {ip}')
@@ -56,8 +69,11 @@ class LabDeviceController:
         logging.info(f'Set rf value to {value}')
         if self.model == 'LDA-908V-8':
             self._last_set_value = int(value)
-            params = {'chnl': 1, 'attn': self._last_set_value}
-            self._send_http_request('setup.cgi', params)
+            self._last_used_ports = set(self._lda_ports)
+            for port in sorted(self._last_used_ports):
+                params = {'chnl': port, 'attn': self._last_set_value}
+                logging.debug('Set attenuation for channel %s with params %s', port, params)
+                self._run_curl_command('setup.cgi', params)
         elif self.model == 'RC4DAT-8G-95':
             self.tn.write(f":CHAN:1:2:3:4:SETATT:{value};".encode('ascii') + b'\r\n')
             self.tn.read_some()
@@ -69,14 +85,23 @@ class LabDeviceController:
 
     def get_rf_current_value(self):
         if self.model == 'LDA-908V-8':
-            params = {'chnl': 1}
-            if self._last_set_value is not None:
-                params['attn'] = self._last_set_value
-            response = self._send_http_request('status.shtm', params)
-            if response is None:
-                return None
-            match = re.search(r'(\d+)', response)
-            return int(match.group(1)) if match else response
+            ports_to_query = self._last_used_ports or self._lda_ports
+            results = {}
+            for port in sorted(ports_to_query):
+                params = {'chnl': port}
+                if self._last_set_value is not None:
+                    params['attn'] = self._last_set_value
+                logging.debug('Query attenuation for channel %s with params %s', port, params)
+                response = self._run_curl_command('status.shtm', params)
+                if response is None:
+                    logging.warning('No response received for channel %s', port)
+                    results[port] = None
+                    continue
+                match = re.search(r'(\d+)', response)
+                results[port] = int(match.group(1)) if match else response
+            if len(results) == 1:
+                return next(iter(results.values()))
+            return results
         if self.model == 'RC4DAT-8G-95':
             self.tn.write("ATT?;".encode('ascii') + b'\r')
             # self.tn.read_some().decode('ascii')
@@ -89,7 +114,7 @@ class LabDeviceController:
             res = self.tn.read_some().decode('utf-8')
             return list(map(int, re.findall(r'\s(\d+);', res)))
 
-    def _send_http_request(self, endpoint, params):
+    def _run_curl_command(self, endpoint, params):
         url = f"http://{self.ip}/{endpoint}"
         query = urlencode(params)
         full_url = f"{url}?{query}" if query else url
@@ -102,6 +127,49 @@ class LabDeviceController:
         except URLError as exc:
             logging.error('Failed to request %s: %s', full_url, exc)
             raise
+
+    @staticmethod
+    def _parse_port_config(raw_ports):
+        if raw_ports is None:
+            return {1}
+        if isinstance(raw_ports, (list, tuple, set)):
+            tokens = list(raw_ports)
+        else:
+            tokens = re.split(r'[\s,]+', str(raw_ports).strip())
+        ports = set()
+        for token in tokens:
+            if token is None:
+                continue
+            token_str = str(token).strip()
+            if not token_str:
+                continue
+            if '-' in token_str:
+                start_str, end_str = token_str.split('-', 1)
+                try:
+                    start = int(start_str)
+                    end = int(end_str)
+                except ValueError as exc:
+                    raise ValueError(f'invalid range segment "{token_str}"') from exc
+                if start > end:
+                    raise ValueError(f'range start greater than end in "{token_str}"')
+                for port in range(start, end + 1):
+                    LabDeviceController._validate_port(port)
+                    ports.add(port)
+            else:
+                try:
+                    port = int(token_str)
+                except ValueError as exc:
+                    raise ValueError(f'invalid port "{token_str}"') from exc
+                LabDeviceController._validate_port(port)
+                ports.add(port)
+        if not ports:
+            raise ValueError('no valid ports specified')
+        return ports
+
+    @staticmethod
+    def _validate_port(port):
+        if port < 1 or port > 8:
+            raise ValueError(f'port {port} is out of range 1-8')
 
     def execute_turntable_cmd(self, type, angle=''):
         if type not in ['gs', 'rt', 'gcp']:

--- a/tests/test_lab_device_controller.py
+++ b/tests/test_lab_device_controller.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.tools.connect_tool.lab_device_controller import LabDeviceController
+
+
+def test_execute_rf_cmd_handles_multiple_ports(monkeypatch):
+    config = {
+        'rf_solution': {
+            'model': 'LDA-908V-8',
+            'LDA-908V-8': {
+                'ports': '1,3-4',
+            },
+        }
+    }
+    monkeypatch.setattr(pytest, 'config', config, raising=False)
+
+    calls = []
+
+    def fake_run(self, endpoint, params):
+        calls.append((endpoint, dict(params)))
+        return 'attn=10'
+
+    monkeypatch.setattr(LabDeviceController, '_run_curl_command', fake_run, raising=False)
+
+    controller = LabDeviceController('192.168.0.1')
+
+    controller.execute_rf_cmd(10)
+
+    setup_calls = [call for call in calls if call[0] == 'setup.cgi']
+    assert [call[1]['chnl'] for call in setup_calls] == [1, 3, 4]
+
+    values = controller.get_rf_current_value()
+
+    status_calls = [call for call in calls if call[0] == 'status.shtm']
+    assert [call[1]['chnl'] for call in status_calls] == [1, 3, 4]
+    assert values == {1: 10, 3: 10, 4: 10}


### PR DESCRIPTION
## Summary
- parse and validate configurable port lists for LDA-908V-8 attenuators
- send setup and status commands for each configured channel and reuse the last set of ports
- add a unit test covering multi-port command execution

## Testing
- pytest tests/test_lab_device_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68d6055aba38832b94f167efd64d330e