### PR TITLE
支持 LDA-908V-8 多通道配置

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,7 +24,7 @@ rf_solution:
     ip_address: 192.168.5.75
   LDA-908V-8:
     ip_address: 192.168.5.200
-    channels: "1"  # 支持范围 1-8，使用逗号分隔多个端口
+    channels: "1"  # 支持范围 1-8，使用逗号分隔多个端口，或使用列表格式
   model: RC4DAT-8G-95
   step:
   - 0


### PR DESCRIPTION
## Summary
- 解析 LDA-908V-8 的 `channels` 配置，支持字符串与列表并生成去重排序的合法通道列表
- 执行和查询射频指令时遍历所有配置的通道，分别下发或读取以验证每个端口
- 更新示例配置注释，说明 `channels` 字段的可选格式

## Testing
- 未执行（未请求）

------
https://chatgpt.com/codex/tasks/task_e_68d62ae6c7ec832b8f77e4fc55cf4044