### PR TITLE
Add About page to Fluent UI navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from qfluentwidgets import FluentIcon, FluentWindow, NavigationItemPosition
 from src.ui.windows_case_config import CaseConfigPage
 from src.ui.rvr_wifi_config import RvrWifiConfigPage
 from src.ui.run import RunPage
+from src.ui.about_page import AboutPage
 from src.ui.report_page import ReportPage
 from qfluentwidgets import setTheme, Theme
 from PyQt5.QtGui import QGuiApplication, QFont
@@ -94,6 +95,8 @@ class MainWindow(FluentWindow):
         self.run_page.reset()
         # 报告页：默认置灰，等待 report_dir 创建后启用
         self.report_page = ReportPage(self)
+        # 关于页
+        self.about_page = AboutPage(self)
         # 导航按钮引用
         self.case_nav_button = self.addSubInterface(
             self.case_config_page, FluentIcon.SETTING, "Config Setup", "Case Config"
@@ -108,6 +111,13 @@ class MainWindow(FluentWindow):
         )
         self.rvr_nav_button.setVisible(True)
         self.rvr_nav_button.setEnabled(False)
+        self.about_nav_button = self.addSubInterface(
+            self.about_page,
+            FluentIcon.INFO,
+            "About",
+        )
+        self.about_nav_button.setVisible(True)
+        self.about_nav_button.setEnabled(True)
         self.run_nav_button = self.addSubInterface(
             self.run_page,
             FluentIcon.PLAY,

--- a/src/ui/about_page.py
+++ b/src/ui/about_page.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from PyQt5.QtWidgets import QVBoxLayout
+from qfluentwidgets import CardWidget, StrongBodyLabel, BodyLabel
+
+from .theme import apply_theme
+
+
+class AboutPage(CardWidget):
+    """Simple about page describing the tool and team."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("aboutPage")
+        apply_theme(self)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(18)
+
+        title_label = StrongBodyLabel("关于 FAE-QA Wi-Fi Test Tool")
+        apply_theme(title_label)
+        layout.addWidget(title_label)
+
+        sections = [
+            (
+                "工具简介",
+                "FAE-QA Wi-Fi Test Tool 用于整合 Wi-Fi 相关测试流程，"
+                "提供用例配置、场景参数和结果展示的全流程体验。"
+                "借助一体化界面帮助工程师快速完成测试执行与数据回顾。",
+            ),
+            (
+                "作者/鸣谢",
+                "工具由 FAE-QA 团队持续维护，感谢 Wi-Fi 研发、验证及自动化平台团队"
+                "在需求梳理、功能验证与体验优化方面提供的大力支持。",
+            ),
+            (
+                "晶晨文化",
+                "秉持“协同、务实、创新”的晶晨文化，我们致力于为客户与伙伴"
+                "提供可靠的无线连接体验，共同打造开放、共赢的生态体系。",
+            ),
+        ]
+
+        for heading, content in sections:
+            header_label = StrongBodyLabel(heading)
+            apply_theme(header_label)
+            layout.addWidget(header_label)
+
+            body_label = BodyLabel(content)
+            body_label.setWordWrap(True)
+            apply_theme(body_label)
+            layout.addWidget(body_label)
+
+        layout.addStretch(1)


### PR DESCRIPTION
## Summary
- add a themed AboutPage card with sections describing the tool and team
- register the About page in the Fluent navigation alongside existing views

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d65304456c832ba94e77eaa4ea42de