### PR TITLE
Fix HyperlinkButton usage on about page

### DIFF
--- a/src/ui/about_page.py
+++ b/src/ui/about_page.py
@@ -108,7 +108,11 @@ class AboutPage(CardWidget):
         ticket_btn.clicked.connect(self._open_ticket_portal)
         support_layout.addWidget(ticket_btn)
 
-        doc_btn = HyperlinkButton("内部文档", self.resources_card)
+        doc_btn = HyperlinkButton(
+            "https://intranet.example.com/docs/wifi-compliance",
+            "内部文档",
+            self.resources_card,
+        )
         doc_btn.clicked.connect(self._open_internal_doc)
         support_layout.addWidget(doc_btn)
         support_layout.addStretch(1)


### PR DESCRIPTION
## Summary
- update the about page hyperlink button to provide the target URL in the constructor to match QFluentWidgets expectations
- keep the existing click handler to continue opening the internal documentation portal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65daea264832b80c26e402bc2c354