### PR TITLE
Improve About page theming and fonts

### DIFF
--- a/src/ui/about_page.py
+++ b/src/ui/about_page.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 
 from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtGui import QDesktopServices, QFont
 from PyQt5.QtWidgets import (
     QVBoxLayout,
     QLabel,
@@ -21,7 +21,14 @@ from PyQt5.QtWidgets import (
 from qfluentwidgets import CardWidget, StrongBodyLabel, PushButton, HyperlinkButton
 
 from src.util.constants import get_build_metadata, Paths
-from .theme import apply_theme, apply_font_and_selection, FONT_FAMILY
+from .theme import (
+    apply_theme,
+    apply_font_and_selection,
+    FONT_FAMILY,
+    FONT_SIZE,
+    STYLE_BASE,
+    TEXT_COLOR,
+)
 
 
 class AboutPage(CardWidget):
@@ -30,7 +37,8 @@ class AboutPage(CardWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("aboutPage")
-        apply_theme(self)
+        apply_theme(self, recursive=True)
+        base_font = QFont(FONT_FAMILY, FONT_SIZE)
 
         layout = QVBoxLayout(self)
         layout.setSpacing(12)
@@ -38,9 +46,13 @@ class AboutPage(CardWidget):
         title = StrongBodyLabel("About")
         apply_theme(title)
         title.setStyleSheet(
-            "border-left: 4px solid #0067c0; padding-left: 8px;"
-            f" font-family: {FONT_FAMILY};"
+            f"""
+            {STYLE_BASE} color:{TEXT_COLOR};
+            border-left: 4px solid #0067c0;
+            padding-left: 8px;
+            """
         )
+        title.setFont(base_font)
         layout.addWidget(title)
 
         self.info_table = QTableWidget(0, 2, self)
@@ -51,33 +63,42 @@ class AboutPage(CardWidget):
         self.info_table.horizontalHeader().setStretchLastSection(True)
         apply_theme(self.info_table)
         apply_font_and_selection(self.info_table)
+        self.info_table.setFont(base_font)
         layout.addWidget(self.info_table)
 
         self.source_label = QLabel("Data Source: Unknown", self)
         apply_theme(self.source_label)
+        self.source_label.setFont(base_font)
         layout.addWidget(self.source_label)
 
         self.resources_card = CardWidget(self)
         apply_theme(self.resources_card)
+        self.resources_card.setFont(base_font)
         resources_layout = QVBoxLayout(self.resources_card)
         resources_layout.setSpacing(8)
 
         resource_title = StrongBodyLabel("Resources & Support")
         apply_theme(resource_title)
         resource_title.setStyleSheet(
-            "border-left: 4px solid #0067c0; padding-left: 8px;"
-            f" font-family: {FONT_FAMILY};"
+            f"""
+            {STYLE_BASE} color:{TEXT_COLOR};
+            border-left: 4px solid #0067c0;
+            padding-left: 8px;
+            """
         )
+        resource_title.setFont(base_font)
         resources_layout.addWidget(resource_title)
 
         config_layout = QHBoxLayout()
         config_layout.setSpacing(6)
         open_config_btn = PushButton("Open config directory", self.resources_card)
         open_config_btn.clicked.connect(lambda: self._open_path(Paths.CONFIG_DIR))
+        open_config_btn.setFont(base_font)
         config_layout.addWidget(open_config_btn)
 
         open_res_btn = PushButton("Open res directory", self.resources_card)
         open_res_btn.clicked.connect(lambda: self._open_path(Paths.RES_DIR))
+        open_res_btn.setFont(base_font)
         config_layout.addWidget(open_res_btn)
         config_layout.addStretch(1)
         resources_layout.addLayout(config_layout)
@@ -87,6 +108,7 @@ class AboutPage(CardWidget):
         for file_name in ("config.yaml", "tool_config.yaml", "compatibility_dut.json"):
             btn = PushButton(file_name, self.resources_card)
             btn.clicked.connect(lambda _, name=file_name: self._open_path(os.path.join(Paths.CONFIG_DIR, name)))
+            btn.setFont(base_font)
             config_files_layout.addWidget(btn)
         config_files_layout.addStretch(1)
         resources_layout.addLayout(config_files_layout)
@@ -96,6 +118,7 @@ class AboutPage(CardWidget):
         for tool in ("ADBKeyboard.apk", "iperf3", "script"):
             btn = PushButton(tool, self.resources_card)
             btn.clicked.connect(lambda _, name=tool: self._open_path(os.path.join(Paths.RES_DIR, name)))
+            btn.setFont(base_font)
             tools_layout.addWidget(btn)
         tools_layout.addStretch(1)
         resources_layout.addLayout(tools_layout)
@@ -104,10 +127,12 @@ class AboutPage(CardWidget):
         support_layout.setSpacing(6)
         email_btn = PushButton("Contact Maintainer", self.resources_card)
         email_btn.clicked.connect(self._show_support_email)
+        email_btn.setFont(base_font)
         support_layout.addWidget(email_btn)
 
         ticket_btn = PushButton("Submit Ticket", self.resources_card)
         ticket_btn.clicked.connect(self._open_ticket_portal)
+        ticket_btn.setFont(base_font)
         support_layout.addWidget(ticket_btn)
 
         doc_btn = HyperlinkButton(
@@ -116,6 +141,7 @@ class AboutPage(CardWidget):
             self.resources_card,
         )
         doc_btn.clicked.connect(self._open_internal_doc)
+        doc_btn.setFont(base_font)
         support_layout.addWidget(doc_btn)
         support_layout.addStretch(1)
         resources_layout.addLayout(support_layout)
@@ -127,6 +153,7 @@ class AboutPage(CardWidget):
         )
         compliance_label.setWordWrap(True)
         apply_theme(compliance_label)
+        compliance_label.setFont(base_font)
         resources_layout.addWidget(compliance_label)
 
         hint_label = QLabel(
@@ -135,6 +162,7 @@ class AboutPage(CardWidget):
         )
         hint_label.setWordWrap(True)
         apply_theme(hint_label)
+        hint_label.setFont(base_font)
         resources_layout.addWidget(hint_label)
 
         layout.addWidget(self.resources_card)


### PR DESCRIPTION
## Summary
- enable recursive theming in the About page so child widgets inherit the shared palette
- replace hard-coded label styles with theme constants to keep typography consistent
- apply the shared font to tables, labels, and buttons created on the About page

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68d7548354c4832b9a02ad88346ac0d3