### PR TITLE
Adjust attenuation step dynamically based on RSSI

### DIFF
--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -10,13 +10,15 @@ Description：
 """
 
 import logging
-import time
+from typing import Optional
+
 from src.test import get_testdata
-from src.test.pyqt_log import log_fixture_params
+from src.test.pyqt_log import log_fixture_params, update_fixture_params
 import pytest
 
 from src.test.performance import (
     common_setup,
+    get_cfg,
     get_rf_step_list,
     init_rf,
     init_router,
@@ -36,17 +38,126 @@ def setup_router(request):
     pytest.dut.kill_iperf()
 
 
+DEFAULT_STEP = 3
+REDUCED_STEP = 2
+RSSI_THRESHOLD = 65
+
+
+class AttenuationScheduler:
+    def __init__(self) -> None:
+        self._last_applied: Optional[int] = None
+        self._current_step = DEFAULT_STEP
+        self._max_db = self._compute_max_db()
+
+    @staticmethod
+    def _compute_max_db() -> int:
+        steps = get_rf_step_list()
+        max_from_steps = steps[-1] if steps else 0
+        try:
+            cfg = get_cfg()
+            configured_max = cfg['rf_solution']['step'][1]
+            max_from_steps = max(max_from_steps, int(configured_max))
+        except (KeyError, TypeError, ValueError, IndexError):
+            pass
+        return max_from_steps
+
+    @property
+    def current_step(self) -> int:
+        return self._current_step
+
+    def next_value(self, base_db: int) -> int:
+        target = min(base_db, self._max_db)
+
+        if self._last_applied is None:
+            applied = target
+        else:
+            candidate = min(self._last_applied + self._current_step, self._max_db)
+            if self._current_step < DEFAULT_STEP and candidate < target:
+                applied = candidate
+            else:
+                applied = max(target, candidate)
+
+        if self._last_applied is not None and applied < self._last_applied:
+            applied = self._last_applied
+
+        if applied != target:
+            logging.info(
+                '根据动态步进策略，将衰减值从计划值 %s 调整为 %s（当前步进 %s dB）',
+                target,
+                applied,
+                self._current_step,
+            )
+
+        self._last_applied = applied
+
+        if applied >= self._max_db and target < self._max_db:
+            logging.info('衰减达到上限 %s dB，后续将维持此值', self._max_db)
+
+        return applied
+
+    def record_rssi(self, rssi_value: Optional[float]) -> None:
+        if rssi_value is None:
+            return
+        try:
+            numeric_rssi = float(rssi_value)
+        except (TypeError, ValueError):
+            numeric_rssi = None
+
+        if numeric_rssi is not None and numeric_rssi > RSSI_THRESHOLD:
+            self._activate_reduced_mode(numeric_rssi)
+        else:
+            self._deactivate_reduced_mode(numeric_rssi)
+
+    def _activate_reduced_mode(self, current_rssi: float) -> None:
+        if self._current_step == REDUCED_STEP:
+            return
+        logging.info(
+            'RSSI %.2f 超过阈值 %s，衰减步进从 %s dB 调整为 %s dB',
+            current_rssi,
+            RSSI_THRESHOLD,
+            DEFAULT_STEP,
+            REDUCED_STEP,
+        )
+        self._current_step = REDUCED_STEP
+
+    def _deactivate_reduced_mode(self, current_rssi: Optional[float]) -> None:
+        if self._current_step != DEFAULT_STEP:
+            logging.info(
+                'RSSI %s 低于或等于阈值 %s，恢复默认 %s dB 步进',
+                current_rssi,
+                RSSI_THRESHOLD,
+                DEFAULT_STEP,
+            )
+        self._current_step = DEFAULT_STEP
+
+
+_attenuation_scheduler = AttenuationScheduler()
+
+
 @pytest.fixture(scope='function', params=get_rf_step_list())
 @log_fixture_params()
 def setup_attenuation(request, setup_router):
     db_set = request.param
     connect_status, router_info = setup_router
-    pytest.dut.get_rssi()
-    if pytest.dut.rssi_num > 65:
-        db_set = 2
-    rf_tool.execute_rf_cmd(db_set)
+
+    applied_db = _attenuation_scheduler.next_value(db_set)
+
+    update_fixture_params(
+        request,
+        {
+            'requested': db_set,
+            'applied': applied_db,
+            'step': _attenuation_scheduler.current_step,
+        },
+    )
+
+    rf_tool.execute_rf_cmd(applied_db)
     logging.info(rf_tool.get_rf_current_value())
-    yield (connect_status, router_info, db_set)
+
+    pytest.dut.get_rssi()
+    _attenuation_scheduler.record_rssi(pytest.dut.rssi_num)
+
+    yield (connect_status, router_info, applied_db)
     pytest.dut.kill_iperf()
 
 

--- a/src/test/pyqt_log.py
+++ b/src/test/pyqt_log.py
@@ -4,6 +4,59 @@ import inspect
 import pytest
 
 
+_ACTUAL_PARAMS_ATTR = "_pyqt_actual_fixture_params"
+
+
+def _ensure_actual_params(node):
+    actual_params = getattr(node, _ACTUAL_PARAMS_ATTR, None)
+    if actual_params is None:
+        actual_params = {}
+        setattr(node, _ACTUAL_PARAMS_ATTR, actual_params)
+    return actual_params
+
+
+def _store_actual_params(request, fixture_name, params):
+    if request is None:
+        return
+    node = getattr(request, "node", None)
+    if node is None:
+        return
+    actual_params = _ensure_actual_params(node)
+    actual_params[fixture_name] = params
+    try:
+        node.user_properties.append((f"{fixture_name}.params", params))
+    except Exception:
+        # user_properties 可能不存在或不可写，忽略
+        pass
+
+
+def get_fixture_actual_params(request, fixture_name, default):
+    if request is None:
+        return default
+    node = getattr(request, "node", None)
+    if node is None:
+        return default
+    actual_params = getattr(node, _ACTUAL_PARAMS_ATTR, None)
+    if not actual_params:
+        return default
+    return actual_params.get(fixture_name, default)
+
+
+def update_fixture_params(request, params, *, tag="FIX", name=None, log=True):
+    """更新 fixture 的实际参数，并可选地重新输出 PyQt 日志。"""
+
+    if request is None:
+        return
+    fixture_name = name or getattr(request, "fixturename", None)
+    if fixture_name is None:
+        fixture_name = "<UNKNOWN_FIXTURE>"
+
+    _store_actual_params(request, fixture_name, params)
+
+    if log:
+        pyqt_log(tag, fixture_name, params)
+
+
 def pyqt_log(tag: str, fixture: str, params):
     def default(o):
         try:
@@ -28,11 +81,15 @@ def log_fixture_params(tag="FIX", name=None):
                     request = candidate
 
             # ——记录日志（容错即可）——
+            fixture_name = name or getattr(request, "fixturename", func.__name__)
+
             try:
-                param_str = str(getattr(request, "param", "<NO_PARAM>"))
+                raw_param = getattr(request, "param", "<NO_PARAM>")
             except Exception:
-                param_str = "<PARAM_ERROR>"
-            pyqt_log(tag, name or func.__name__, param_str)
+                raw_param = "<PARAM_ERROR>"
+
+            params_to_log = get_fixture_actual_params(request, fixture_name, raw_param)
+            pyqt_log(tag, fixture_name, params_to_log)
 
             # ——调用原函数，并保持其生成器/返回值语义——
             result = func(*args, **kwargs)


### PR DESCRIPTION
## Summary
- refactor the attenuation scheduler to change its step size when RSSI crosses the threshold instead of pre-scheduling fixed 2 dB values
- expose the applied attenuation and step through the fixture logging helper so pytest hooks can see the dynamic values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8a6ce126c832b9980c8e42d8ecb6b