### PR TITLE
Use router_str for router fixture ids

### DIFF
--- a/src/test/performance/test_wifi_peak_throughput.py
+++ b/src/test/performance/test_wifi_peak_throughput.py
@@ -13,13 +13,14 @@ import logging
 from src.test import get_testdata
 from src.test.pyqt_log import log_fixture_params
 import pytest
+from src.tools.router_tool.Router import router_str
 
 from src.test.performance import common_setup, init_router
 
 _test_data = get_testdata(init_router())
 
 
-@pytest.fixture(scope='session', params=_test_data, ids=[str(i) for i in _test_data])
+@pytest.fixture(scope='session', params=_test_data, ids=[router_str(i) for i in _test_data])
 @log_fixture_params()
 def setup_router(request):
     router_info = request.param

--- a/src/test/performance/test_wifi_rvo.py
+++ b/src/test/performance/test_wifi_rvo.py
@@ -14,6 +14,7 @@ import time
 from typing import Optional, Tuple
 
 import pytest
+from src.tools.router_tool.Router import router_str
 
 from src.test import get_testdata
 from src.test.pyqt_log import log_fixture_params
@@ -161,7 +162,7 @@ rf_tool = init_rf()
 _test_data = get_testdata(router)
 
 
-@pytest.fixture(scope='session', params=_test_data, ids=[str(i) for i in _test_data])
+@pytest.fixture(scope='session', params=_test_data, ids=[router_str(i) for i in _test_data])
 @log_fixture_params()
 def setup_router(request):
     router_info = request.param

--- a/src/test/performance/test_wifi_rvr.py
+++ b/src/test/performance/test_wifi_rvr.py
@@ -15,6 +15,7 @@ from typing import Optional
 from src.test import get_testdata
 from src.test.pyqt_log import log_fixture_params, update_fixture_params
 import pytest
+from src.tools.router_tool.Router import router_str
 
 from src.test.performance import (
     common_setup,
@@ -28,7 +29,7 @@ _test_data = get_testdata(init_router())
 rf_tool = init_rf()
 
 
-@pytest.fixture(scope='session', params=_test_data, ids=[str(i) for i in _test_data])
+@pytest.fixture(scope='session', params=_test_data, ids=[router_str(i) for i in _test_data])
 @log_fixture_params()
 def setup_router(request):
     router_info = request.param

--- a/src/test/performance/test_wifi_rvr_rvo.py
+++ b/src/test/performance/test_wifi_rvr_rvo.py
@@ -14,6 +14,7 @@ import time
 from src.test import get_testdata
 from src.test.pyqt_log import log_fixture_params
 import pytest
+from src.tools.router_tool.Router import router_str
 
 from src.test.performance import (
     common_setup,
@@ -30,7 +31,7 @@ rf_tool = init_rf()
 corner_tool = init_corner()
 
 
-@pytest.fixture(scope='session', params=_test_data, ids=[str(i) for i in _test_data])
+@pytest.fixture(scope='session', params=_test_data, ids=[router_str(i) for i in _test_data])
 @log_fixture_params()
 def setup_router(request):
     router_info = request.param


### PR DESCRIPTION
## Summary
- import the shared router_str helper in Wi-Fi performance tests
- format setup_router fixture ids with router_str for consistent router labels

## Testing
- pytest --collect-only src/test/performance/test_wifi_peak_throughput.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d8cac2ff00832b81dcca8ee5368b8b