### PR TITLE
Adjust router string output

### DIFF
--- a/src/tools/router_tool/Router.py
+++ b/src/tools/router_tool/Router.py
@@ -13,11 +13,26 @@ from src.util.constants import RouterConst
 
 
 def _info(info):
-    return 'Default' if info == None else info
+    if info is None:
+        return 'Default'
+
+    cleaned = str(info).strip()
+    if not cleaned or cleaned.lower() in {"none", "null"}:
+        return 'Default'
+
+    return cleaned
 
 
 def router_str(self):
-    return f'{_info(self.band)},{_info(self.ssid)},{_info(self.wireless_mode)},{_info(self.channel)},{_info(self.bandwidth)},{_info(self.security_mode)}'
+    parts = (
+        _info(self.band),
+        _info(self.ssid),
+        _info(self.wireless_mode),
+        _info(self.channel),
+        _info(self.bandwidth),
+        _info(self.security_mode),
+    )
+    return ''.join(parts)
 
 
 RUN_SETTING_ACTIVITY = RouterConst.RUN_SETTING_ACTIVITY


### PR DESCRIPTION
## Summary
- change router_str to concatenate sanitized router fields without extra delimiter characters

## Testing
- pytest --collect-only src/test/performance/test_wifi_rvr.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68d90684e4d8832b9491d59ff06850ad