### PR TITLE
feat: cascade config and test results to mysql

### DIFF
--- a/docs/db_schema_plan.md
+++ b/docs/db_schema_plan.md
@@ -1,0 +1,102 @@
+# 数据库级联建表方案
+
+## 总体目标
+在现有配置保存与测试执行流程中，引入数据库持久层，将配置文件(`config`)中的层级信息按照 DUT、Execution、Test Case 三层分别持久化到 MySQL。通过级联建表机制保证：
+
+1. 每次保存配置或执行测试时，数据库中的结构和数据与实际配置完全一致；
+2. 能够支持当前的性能(performance)测试目录，也能方便扩展到后续的其他测试目录；
+3. 表之间建立清晰的父子关系，便于查询与追溯；
+4. 重复执行时自动清理旧表，保证结构及数据的一致性。
+
+## 数据模型设计
+
+### 1. DUT 层（第一层表）
+- **表名：** `dut_settings`
+- **主键：** `dut_id`（自增或 UUID）
+- **字段：**
+  - 初始字段集包含 `connect_type`、`software_version`、`hardware_version`、`android_version`、`fpga_version`、`serial_port`、`created_at`（默认当前时间）、`updated_at`；
+  - **动态扩展字段：** 当 `config` 中出现新的 DUT 属性（例如新增的硬件标签、固件配置等）时，通过比对元数据表或 `INFORMATION_SCHEMA`，对缺失字段执行 `ALTER TABLE dut_settings ADD COLUMN`。
+- **数据来源：** `config` 中 DUT Settings 的全部字段，包含未来新增项。
+- **写入策略：**
+  - 每次保存配置时，根据唯一键（如 `serial_number` 或组合键）判断是否存在，存在则更新，不存在则插入；
+  - 插入/更新前，先完成字段比对与扩展，确保所有配置键都有对应列；
+  - 返回 `dut_id` 用于后续层级关联。
+
+### 2. Execution 层（第二层表）
+- **表名：** `execution_settings`
+- **主键：** `execution_id`
+- **外键：**
+  - `dut_id` 引用 `dut_settings.dut_id`，确保 Execution 级联在 DUT 上；
+- **字段策略：**
+  - **动态字段生成：** Execution Settings 中出现的所有键值对都需要同步到表结构中。初始化时先落地一组核心字段（如 `router`、`test_type`、`csv_path`、`script_branch`、`test_time`、`created_at`、`updated_at`），随后在每次写入前比对配置中的键；若发现表中不存在的字段，则通过 `ALTER TABLE execution_settings ADD COLUMN` 的方式补充对应列。
+  - **字段类型推断：** 优先根据配置值类型（布尔、整数、浮点、字符串、列表/字典）映射到 MySQL 类型；列表/字典统一落在 `JSON` 字段。
+  - **字段变更记录：** 通过元数据表（例如 `schema_registry`）记录当前 Execution 表所包含的字段及其类型，便于后续 diff 与维护。
+- **数据来源：** Execution Settings 的全部字段，包含未来新增项。
+- **写入策略：**
+  - 每次执行测试时创建一条新的 execution 记录，关联 `dut_id`；
+  - 若在配置保存阶段需要预写，则先创建占位记录，在执行时更新真实时间与状态；
+  - 动态字段写入时，需保证在事务中先完成字段补全，再执行 `INSERT`/`UPDATE`。
+
+### 3. Test Case 层（第三层表）
+- **表名：** 动态按测试目录命名，例如 `performance`；后续若有 `stability`、`throughput` 等目录，同样按目录名命名。
+- **主键：** `id`（自增）
+- **外键：**
+  - `execution_id` 引用 `execution_settings.execution_id`；
+  - `dut_id` 引用 `dut_settings.dut_id`，确保 Test Case 层同时能从 Execution 与 DUT 两条路径进行级联查询。
+- **字段：** 针对 `testResult.log_file` 中性能测试记录的结构化字段，例如：
+  - `case_name`
+  - `sub_case`
+  - `metric`
+  - `unit`
+  - `value`
+  - `threshold`
+  - `result`（PASS/FAIL）
+  - `log_path`
+  - `created_at`
+- **写入策略：**
+  - 在执行脚本前，根据即将执行的测试目录列表，依次对每个目录执行：
+    1. `DROP TABLE IF EXISTS {table_name}`；
+    2. `CREATE TABLE {table_name} (...)`。建表时包含 `execution_id` 与 `dut_id` 两个外键，以保证双向级联；
+  - 测试过程中，当解析 `testResult.log_file` 时，将记录写入对应目录的表，关联当前 `execution_id` 与 `dut_id`；
+  - 若某目录无数据，也可保留空表以保证结构一致；
+  - 如遇新的性能指标字段，同样通过 `ALTER TABLE` 动态扩展列，或在重建时根据解析得到的字段集合生成完整结构。
+
+## 级联建表与写入流程
+
+1. **配置保存阶段**
+   - 解析配置文件，构造 DUT Settings 数据模型。
+   - 调用数据库操作层 `upsert_dut_settings(data)`，在内部通过 `sync_table_schema('dut_settings', data)` 自动补齐字段，返回 `dut_id`。
+   - 如需提前建立 Execution 记录，可调用 `create_execution_placeholder(dut_id, execution_config)`，在内部通过 `sync_table_schema('execution_settings', execution_config)` 自动补齐字段并写入初始信息。
+
+2. **执行测试阶段**
+   - 根据当前执行上下文获取 `dut_id` 与 `execution_id`；如果执行阶段才创建 Execution，需调用 `create_execution(dut_id, execution_config)`，内部同样执行 `sync_table_schema('execution_settings', execution_config)`。
+   - 构建待执行的测试目录列表（如 `performance`）。
+   - 遍历目录列表，对每个目录调用 `recreate_test_table(table_name, schema_definition)` 完成级联建表：
+     - 使用统一的建表模板，字段集合由解析器提供。
+     - 建表前通过 `sync_table_schema(table_name, schema_definition)` 与元数据表完成字段对齐。
+   - 在测试脚本解析日志或生成结果时，通过 `insert_test_result(table_name, dut_id, execution_id, record)` 写入数据。
+
+3. **事务与一致性**
+   - 建议在配置保存和执行写入关键步骤使用事务：
+     - DUT / Execution 写入可各自封装在事务内。
+     - Test Case 数据的 `DROP + CREATE + INSERT` 需要确保操作顺序一致，可使用单独事务。
+   - 如遇异常（例如连接失败或建表错误），回滚并在脚本中输出错误日志，确保不会影响原有脚本逻辑。
+
+## 扩展与维护
+
+- **字段变动：**
+  - 引入统一的 `schema_registry` 元数据表，记录每个业务表当前的字段、数据类型与最后一次同步时间；
+  - 在 DUT 与 Execution 写入前，通过对比配置键与元数据表决定是否需要 `ALTER TABLE`；
+  - 提供 `sync_table_schema(table_name, payload)` 通用接口，自动完成列存在性校验与新增。
+- **目录扩展：** 新增测试目录时，只需在配置或执行流程中传入目录名与对应字段结构，自动完成建表与写入。
+- **查询接口：** 可在后续补充查询工具，用于按 `dut_id`、`execution_id` 检索测试结果。
+
+## 实施步骤概览
+
+1. 新增数据库操作封装模块，提供连接管理、建表、写入、事务等函数。
+2. 在配置保存流程中调用 DUT 层写入逻辑，返回 `dut_id`。
+3. 在执行流程中调用 Execution 层写入逻辑，生成 `execution_id`。
+4. 在测试执行前对每个测试目录执行 `DROP + CREATE`，建立对应 Test Case 表。
+5. 在日志解析阶段，将结果按目录写入对应表，关联 `execution_id`。
+6. 增加异常处理与日志输出，确保数据库操作失败时仍可继续执行脚本（或给出明确提示）。
+

--- a/src/tools/config_loader.py
+++ b/src/tools/config_loader.py
@@ -14,6 +14,7 @@ from src.tools.config_sections import (
     save_config_sections,
     split_config_data,
 )
+from src.tools.mysql_tool.MySqlControl import sync_configuration
 from src.util.constants import get_config_base
 
 
@@ -119,3 +120,7 @@ def save_config(config: dict | None) -> None:
     legacy_path = base_dir / "config.yaml"
     _write_yaml(legacy_path, merged)
     load_config.cache_clear()
+    try:
+        sync_configuration(merged)
+    except Exception:
+        logging.exception("Failed to sync configuration to database")

--- a/src/tools/mysql_tool/MySqlControl.py
+++ b/src/tools/mysql_tool/MySqlControl.py
@@ -5,12 +5,12 @@
 # @File    : MySqlControl.py
 
 import csv
-import hashlib
+import json
 import logging
+import re
 import sys
 import yaml
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -21,57 +21,7 @@ BASE_DIR = Path(__file__).resolve().parents[3]
 if str(BASE_DIR) not in sys.path:
     sys.path.insert(0, str(BASE_DIR))
 
-DATA_TABLE_NAME = "performance_data"
-CSV_FIELD_MAP: Tuple[Tuple[str, str], ...] = (
-    ("SerianNumber", "serial_number"),
-    ("Test_Category", "test_category"),
-    ("Sub_Category", "sub_category"),
-    ("Coex_Method", "coex_method"),
-    ("BT_WF_Isolation", "bt_wf_isolation"),
-    ("Standard", "standard"),
-    ("Freq_Band", "freq_band"),
-    ("BW", "bw"),
-    ("Data_Rate", "data_rate"),
-    ("CH_Freq_MHz", "ch_freq_mhz"),
-    ("Protocol", "protocol"),
-    ("Direction", "direction"),
-    ("Total_Path_Loss", "total_path_loss"),
-    ("RxP", "rxp"),
-    ("DB", "db_value"),
-    ("RSSI", "rssi"),
-    ("Angel", "angle"),
-    ("Data_RSSI", "data_rssi"),
-    ("MCS_Rate", "mcs_rate"),
-    ("Throughput", "throughput"),
-    ("Expect_Rate", "expect_rate"),
-)
-TABLE_COLUMN_SQL: Tuple[Tuple[str, str], ...] = (
-    ("execution_id", "INT"),
-    ("data_type", "VARCHAR(32) NOT NULL"),
-    ("file_name", "VARCHAR(255) NOT NULL"),
-    ("serial_number", "VARCHAR(128)"),
-    ("test_category", "VARCHAR(128)"),
-    ("sub_category", "VARCHAR(128)"),
-    ("coex_method", "VARCHAR(128)"),
-    ("bt_wf_isolation", "VARCHAR(128)"),
-    ("standard", "VARCHAR(64)"),
-    ("freq_band", "VARCHAR(64)"),
-    ("bw", "VARCHAR(64)"),
-    ("data_rate", "VARCHAR(64)"),
-    ("ch_freq_mhz", "VARCHAR(64)"),
-    ("protocol", "VARCHAR(64)"),
-    ("direction", "VARCHAR(64)"),
-    ("total_path_loss", "VARCHAR(64)"),
-    ("rxp", "VARCHAR(64)"),
-    ("db_value", "VARCHAR(64)"),
-    ("rssi", "VARCHAR(64)"),
-    ("angle", "VARCHAR(64)"),
-    ("data_rssi", "VARCHAR(64)"),
-    ("mcs_rate", "VARCHAR(64)"),
-    ("throughput", "VARCHAR(64)"),
-    ("expect_rate", "VARCHAR(64)"),
-)
-TABLE_COLUMN_NAMES: Tuple[str, ...] = tuple(name for name, _ in TABLE_COLUMN_SQL)
+from src.tools.config_sections import split_config_data
 
 
 def _load_mysql_config() -> Dict[str, Any]:
@@ -124,49 +74,216 @@ def _ensure_database_exists(config: Dict[str, Any]) -> None:
         connection.close()
 
 
-@dataclass
-class DataRecord:
-    """Row stored in performance_data table."""
+_IDENTIFIER_RE = re.compile(r"[^0-9a-zA-Z]+")
 
-    id: int
-    data_type: str
-    file_name: str
-    serial_number: str
-    test_category: str
-    sub_category: str
-    coex_method: str
-    bt_wf_isolation: str
-    standard: str
-    freq_band: str
-    bw: str
-    data_rate: str
-    ch_freq_mhz: str
-    protocol: str
-    direction: str
-    total_path_loss: str
-    rxp: str
-    db_value: str
-    rssi: str
-    angle: str
-    data_rssi: str
-    mcs_rate: str
-    throughput: str
-    expect_rate: str
-    created_at: datetime
-    updated_at: datetime
+
+@dataclass(frozen=True)
+class ColumnDefinition:
+    name: str
+    definition: str
+
+
+@dataclass(frozen=True)
+class HeaderMapping:
+    original: str
+    sanitized: str
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    dut_id: int
+    execution_id: int
+
+
+@dataclass(frozen=True)
+class TestResultContext:
+    dut_id: int
+    execution_id: int
+    case_path: Optional[str]
+    data_type: Optional[str]
+    log_file_path: str
+
+
+class IdentifierBuilder:
+    """生成唯一且符合 SQL 规范的列名。"""
+
+    def __init__(self) -> None:
+        self._counts: Dict[str, int] = {}
+
+    def build(self, parts: Sequence[str], *, fallback: str = "field") -> str:
+        sanitized_parts: List[str] = []
+        for part in parts:
+            sanitized = _IDENTIFIER_RE.sub("_", str(part).strip())
+            sanitized = sanitized.strip("_").lower()
+            if not sanitized:
+                sanitized = fallback
+            if sanitized[0].isdigit():
+                sanitized = f"f_{sanitized}"
+            sanitized_parts.append(sanitized)
+        base = "_".join(sanitized_parts) if sanitized_parts else fallback
+        if not base:
+            base = fallback
+        count = self._counts.get(base, 0)
+        self._counts[base] = count + 1
+        if count:
+            return f"{base}_{count}"
+        return base
+
+
+def _flatten_section(
+    data: Any, builder: IdentifierBuilder, prefix: Tuple[str, ...] = ()
+) -> List[Tuple[str, Any, str]]:
+    if isinstance(data, dict):
+        items: List[Tuple[str, Any, str]] = []
+        for key, value in data.items():
+            items.extend(_flatten_section(value, builder, prefix + (str(key),)))
+        return items
+    path = ".".join(prefix) if prefix else "value"
+    column_name = builder.build(prefix or ("value",), fallback="field")
+    return [(column_name, data, path)]
+
+
+def _infer_sql_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "TINYINT(1)"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "BIGINT"
+    if isinstance(value, float):
+        return "DOUBLE"
+    if isinstance(value, (list, tuple, dict)):
+        return "JSON"
+    return "TEXT"
+
+
+def _normalize_value(value: Any, sql_type: str) -> Any:
+    if value is None:
+        return None
+    if sql_type == "TINYINT(1)":
+        return 1 if bool(value) else 0
+    if sql_type == "BIGINT":
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    if sql_type == "DOUBLE":
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    if sql_type == "JSON":
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _build_section_payload(
+    section: dict | None,
+) -> Tuple[List[ColumnDefinition], List[Any], Dict[str, str]]:
+    if not isinstance(section, dict) or not section:
+        return [], [], {}
+    builder = IdentifierBuilder()
+    flattened = _flatten_section(section, builder)
+    columns: List[ColumnDefinition] = []
+    values: List[Any] = []
+    mapping: Dict[str, str] = {}
+    for column_name, raw_value, path in flattened:
+        sql_type = _infer_sql_type(raw_value)
+        columns.append(ColumnDefinition(column_name, f"{sql_type} NULL DEFAULT NULL"))
+        values.append(_normalize_value(raw_value, sql_type))
+        mapping[column_name] = path
+    return columns, values, mapping
+
+
+def _sanitize_single_identifier(value: str, *, fallback: str) -> str:
+    sanitized = _IDENTIFIER_RE.sub("_", value.strip())
+    sanitized = sanitized.strip("_").lower()
+    if not sanitized:
+        sanitized = fallback
+    if sanitized[0].isdigit():
+        prefix = fallback[0] if fallback else "t"
+        sanitized = f"{prefix}_{sanitized}"
+    return sanitized
+
+
+def _resolve_case_table_name(
+    case_path: Optional[str], data_type: Optional[str]
+) -> str:
+    candidate = None
+    if case_path:
+        path = Path(case_path)
+        candidate = path.parent.name or path.stem
+    if not candidate and data_type:
+        candidate = data_type
+    if not candidate:
+        candidate = "test_results"
+    return _sanitize_single_identifier(candidate, fallback="test_results")
+
+
+def _drop_and_create_table(
+    client: "MySqlClient", table_name: str, columns: Sequence[ColumnDefinition]
+) -> None:
+    client.execute(f"DROP TABLE IF EXISTS `{table_name}`")
+    column_lines = [f"`{column.name}` {column.definition}" for column in columns]
+    statements = [
+        f"CREATE TABLE `{table_name}` (",
+        "    id INT PRIMARY KEY AUTO_INCREMENT,",
+    ]
+    statements.extend(f"    {line}," for line in column_lines)
+    statements.extend(
+        [
+            "    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,",
+            "    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        ]
+    )
+    create_sql = "\n".join(statements)
+    client.execute(create_sql)
+
+
+def _insert_rows(
+    client: "MySqlClient",
+    table_name: str,
+    columns: Sequence[ColumnDefinition],
+    rows: Sequence[Sequence[Any]],
+) -> List[int]:
+    if not rows:
+        return []
+    if not columns:
+        return [client.insert(f"INSERT INTO `{table_name}` () VALUES ()") for _ in rows]
+    column_names = ", ".join(f"`{column.name}`" for column in columns)
+    placeholders = ", ".join(["%s"] * len(columns))
+    sql = f"INSERT INTO `{table_name}` ({column_names}) VALUES ({placeholders})"
+    return [client.insert(sql, row) for row in rows]
+
+
+def _read_csv_rows(file_path: Path) -> Tuple[List[str], List[Dict[str, Any]]]:
+    encodings = ("utf-8-sig", "gbk", "utf-8")
+    for encoding in encodings:
+        try:
+            with file_path.open(encoding=encoding, newline="") as handle:
+                reader = csv.DictReader(handle)
+                headers = reader.fieldnames or []
+                rows = [dict(row) for row in reader]
+                if headers:
+                    return headers, rows
+        except UnicodeDecodeError:
+            continue
+    with file_path.open(encoding="utf-8", errors="ignore", newline="") as handle:
+        reader = csv.DictReader(handle)
+        headers = reader.fieldnames or []
+        rows = [dict(row) for row in reader]
+    return headers, rows
+
+
+def _build_header_mappings(headers: Sequence[str]) -> List[HeaderMapping]:
+    builder = IdentifierBuilder()
+    mappings: List[HeaderMapping] = []
+    for header in headers:
+        mappings.append(HeaderMapping(header, builder.build((header,), fallback="column")))
+    return mappings
 
 
 class MySqlClient:
-    """Thin wrapper around pymysql with helpers for CSV storage."""
-
-    def _table_schema_matches(self) -> bool:
-        try:
-            rows = self.query_all(f"SHOW COLUMNS FROM {DATA_TABLE_NAME}")
-        except pymysql.err.ProgrammingError:
-            return False
-        expected = ["id"] + list(TABLE_COLUMN_NAMES) + ["created_at", "updated_at"]
-        actual = [row["Field"] for row in rows]
-        return actual == expected
+    """Thin wrapper around pymysql with helpers for schema operations."""
 
     def __init__(self, *, autocommit: bool = False):
         self._connection: Optional[pymysql.connections.Connection] = None
@@ -217,6 +334,21 @@ class MySqlClient:
             logging.error("SQL executemany failed: %s", exc)
             raise
 
+    def insert(self, sql: str, args: Optional[Sequence[Any]] = None) -> int:
+        logging.debug("Insert SQL: %s | args: %s", sql, args)
+        try:
+            with self._connection.cursor() as cursor:
+                cursor.execute(sql, args)
+                last_id = cursor.lastrowid
+            if not self._connection.get_autocommit():
+                self._connection.commit()
+            return int(last_id or 0)
+        except Exception as exc:
+            if not self._connection.get_autocommit():
+                self._connection.rollback()
+            logging.error("SQL insert failed: %s", exc)
+            raise
+
     def query_one(self, sql: str, args: Optional[Sequence[Any]] = None) -> Optional[Dict[str, Any]]:
         logging.debug("Query one SQL: %s | args: %s", sql, args)
         with self._connection.cursor() as cursor:
@@ -252,150 +384,6 @@ class MySqlClient:
             self.rollback()
         self.close()
 
-    def ensure_data_table(self) -> None:
-        column_sql = ",\n            ".join(f"{name} {definition}" for name, definition in TABLE_COLUMN_SQL)
-        create_sql = f"""
-        CREATE TABLE IF NOT EXISTS {DATA_TABLE_NAME} (
-            id INT PRIMARY KEY AUTO_INCREMENT,
-            {column_sql},
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-            INDEX idx_data_type_file (data_type, file_name)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-        """
-        self.execute(create_sql)
-
-    def drop_data_table(self) -> None:
-        self.execute(f"DROP TABLE IF EXISTS {DATA_TABLE_NAME}")
-
-    def import_csv(self, data_type: str, file_path: str, *, overwrite: bool = True) -> int:
-        target = Path(file_path)
-        if not target.is_file():
-            raise FileNotFoundError(f"File not found: {file_path}")
-        with target.open(encoding="utf-8-sig", newline="") as csv_file:
-            reader = csv.DictReader(csv_file)
-            if reader.fieldnames is None:
-                raise ValueError("CSV file has no header row.")
-            rows: List[List[str]] = []
-            for row in reader:
-                values = [str(row.get(csv_key, "")).strip() for csv_key, _ in CSV_FIELD_MAP]
-                rows.append(values)
-        if not rows:
-            logging.warning("CSV file %s does not contain any data rows.", target)
-            return 0
-        column_names = ",".join(name for _, name in CSV_FIELD_MAP)
-        placeholders = ",".join(["%s"] * (len(CSV_FIELD_MAP) + 2))
-        insert_sql = (
-            f"INSERT INTO {DATA_TABLE_NAME} (data_type, file_name, {column_names}) "
-            f"VALUES ({placeholders})"
-        )
-        params = [[data_type.upper(), target.name, *values] for values in rows]
-        with self._connection.cursor() as cursor:
-            if overwrite:
-                cursor.execute(
-                    f"DELETE FROM {DATA_TABLE_NAME} WHERE data_type=%s AND file_name=%s",
-                    (data_type.upper(), target.name),
-                )
-            cursor.executemany(insert_sql, params)
-        self.commit()
-        logging.info(
-            "Stored %s rows from %s into %s", len(rows), target.name, DATA_TABLE_NAME
-        )
-        return len(rows)
-
-    def delete_record(self, record_id: int) -> int:
-        affected = self.execute(f"DELETE FROM {DATA_TABLE_NAME} WHERE id=%s", (record_id,))
-        logging.info("Deleted record %s (rows affected: %s)", record_id, affected)
-        return affected
-
-    def list_records(
-        self,
-        *,
-        data_type: Optional[str] = None,
-        limit: int = 20,
-        offset: int = 0,
-    ) -> List[DataRecord]:
-        select_columns = TABLE_COLUMN_NAMES
-        sql = (
-            f"SELECT id, {', '.join(select_columns)}, created_at, updated_at FROM {DATA_TABLE_NAME}"
-        )
-        params: List[Any] = []
-        if data_type:
-            sql += " WHERE data_type=%s"
-            params.append(data_type.upper())
-        sql += " ORDER BY created_at DESC LIMIT %s OFFSET %s"
-        params.extend([limit, offset])
-        rows = self.query_all(sql, params)
-        return [
-            DataRecord(
-                id=row["id"],
-                data_type=row["data_type"],
-                file_name=row["file_name"],
-                serial_number=row["serial_number"],
-                test_category=row["test_category"],
-                sub_category=row["sub_category"],
-                coex_method=row["coex_method"],
-                bt_wf_isolation=row["bt_wf_isolation"],
-                standard=row["standard"],
-                freq_band=row["freq_band"],
-                bw=row["bw"],
-                data_rate=row["data_rate"],
-                ch_freq_mhz=row["ch_freq_mhz"],
-                protocol=row["protocol"],
-                direction=row["direction"],
-                total_path_loss=row["total_path_loss"],
-                rxp=row["rxp"],
-                db_value=row["db_value"],
-                rssi=row["rssi"],
-                angle=row["angle"],
-                data_rssi=row["data_rssi"],
-                mcs_rate=row["mcs_rate"],
-                throughput=row["throughput"],
-                expect_rate=row["expect_rate"],
-                created_at=row["created_at"],
-                updated_at=row["updated_at"],
-            )
-            for row in rows
-        ]
-
-    def get_record(self, record_id: int) -> Optional[DataRecord]:
-        select_columns = TABLE_COLUMN_NAMES
-        sql = (
-            f"SELECT id, {', '.join(select_columns)}, created_at, updated_at FROM {DATA_TABLE_NAME} "
-            "WHERE id=%s"
-        )
-        row = self.query_one(sql, (record_id,))
-        if not row:
-            return None
-        return DataRecord(
-            id=row["id"],
-            data_type=row["data_type"],
-            file_name=row["file_name"],
-            serial_number=row["serial_number"],
-            test_category=row["test_category"],
-            sub_category=row["sub_category"],
-            coex_method=row["coex_method"],
-            bt_wf_isolation=row["bt_wf_isolation"],
-            standard=row["standard"],
-            freq_band=row["freq_band"],
-            bw=row["bw"],
-            data_rate=row["data_rate"],
-            ch_freq_mhz=row["ch_freq_mhz"],
-            protocol=row["protocol"],
-            direction=row["direction"],
-            total_path_loss=row["total_path_loss"],
-            rxp=row["rxp"],
-            db_value=row["db_value"],
-            rssi=row["rssi"],
-            angle=row["angle"],
-            data_rssi=row["data_rssi"],
-            mcs_rate=row["mcs_rate"],
-            throughput=row["throughput"],
-            expect_rate=row["expect_rate"],
-            created_at=row["created_at"],
-            updated_at=row["updated_at"],
-        )
-
     def __del__(self):  # pragma: no cover
         try:
             self.close()
@@ -403,73 +391,225 @@ class MySqlClient:
             pass
 
 
+class ConfigSchemaSynchronizer:
+    """根据配置动态同步 DUT 与 Execution 表结构及数据。"""
+
+    DUT_TABLE = "dut_settings"
+    EXECUTION_TABLE = "execution_settings"
+
+    def __init__(self, client: MySqlClient) -> None:
+        self._client = client
+
+    def sync(self, config: dict) -> SyncResult:
+        dut_section, execution_section = split_config_data(config)
+        dut_columns, dut_values, dut_mapping = _build_section_payload(dut_section)
+        execution_columns, execution_values, execution_mapping = _build_section_payload(execution_section)
+
+        dut_id = self._create_table_and_insert(
+            self.DUT_TABLE, dut_columns, dut_values, dut_mapping
+        )
+        execution_columns.insert(0, ColumnDefinition("dut_id", "INT NOT NULL"))
+        execution_values.insert(0, dut_id)
+        execution_mapping["dut_id"] = "dut.id"
+        execution_id = self._create_table_and_insert(
+            self.EXECUTION_TABLE, execution_columns, execution_values, execution_mapping
+        )
+        return SyncResult(dut_id=dut_id, execution_id=execution_id)
+
+    def _create_table_and_insert(
+        self,
+        table_name: str,
+        columns: Sequence[ColumnDefinition],
+        values: Sequence[Any],
+        mapping: Dict[str, str],
+    ) -> int:
+        _drop_and_create_table(self._client, table_name, columns)
+        if mapping:
+            logging.debug("%s column mapping: %s", table_name, mapping)
+        inserted_ids = _insert_rows(self._client, table_name, columns, [values])
+        if not inserted_ids:
+            raise RuntimeError(f"Failed to insert row into {table_name}")
+        return inserted_ids[0]
+
+
+class TestResultTableManager:
+    """负责针对测试用例目录创建结果表并写入日志数据。"""
+
+    BASE_COLUMNS: Tuple[ColumnDefinition, ...] = (
+        ColumnDefinition("dut_id", "INT NOT NULL"),
+        ColumnDefinition("execution_id", "INT NOT NULL"),
+        ColumnDefinition("case_path", "TEXT NULL DEFAULT NULL"),
+        ColumnDefinition("data_type", "VARCHAR(64) NULL DEFAULT NULL"),
+        ColumnDefinition("log_file_path", "TEXT NULL DEFAULT NULL"),
+        ColumnDefinition("row_index", "INT NOT NULL"),
+    )
+
+    def __init__(self, client: MySqlClient) -> None:
+        self._client = client
+
+    def store_results(
+        self,
+        table_name: str,
+        headers: Sequence[str],
+        rows: Sequence[Dict[str, Any]],
+        context: TestResultContext,
+    ) -> int:
+        header_mappings = _build_header_mappings(headers)
+        logging.debug(
+            "%s header mapping: %s",
+            table_name,
+            {mapping.sanitized: mapping.original for mapping in header_mappings},
+        )
+        columns = list(self.BASE_COLUMNS) + [
+            ColumnDefinition(mapping.sanitized, "TEXT NULL DEFAULT NULL")
+            for mapping in header_mappings
+        ]
+        _drop_and_create_table(self._client, table_name, columns)
+
+        insert_columns = [column.name for column in columns]
+        placeholders = ", ".join(["%s"] * len(insert_columns))
+        sql = (
+            f"INSERT INTO `{table_name}` ("
+            f"{', '.join(f'`{name}`' for name in insert_columns)}) "
+            f"VALUES ({placeholders})"
+        )
+        if not rows:
+            logging.info(
+                "No rows parsed from %s, skip inserting into %s",
+                context.log_file_path,
+                table_name,
+            )
+            return 0
+
+        values_list: List[List[Any]] = []
+        for index, row in enumerate(rows, start=1):
+            row_values: List[Any] = [
+                context.dut_id,
+                context.execution_id,
+                context.case_path,
+                context.data_type.upper() if context.data_type else None,
+                context.log_file_path,
+                index,
+            ]
+            for mapping in header_mappings:
+                value = row.get(mapping.original)
+                if value is None:
+                    row_values.append(None)
+                else:
+                    text = str(value).strip()
+                    row_values.append(text if text else None)
+            values_list.append(row_values)
+
+        affected = self._client.executemany(sql, values_list)
+        logging.info("Stored %s rows into %s", affected, table_name)
+        return affected
+
+
+_LATEST_SYNC_RESULT: Optional[SyncResult] = None
+
+
+def sync_configuration(config: dict | None) -> Optional[SyncResult]:
+    """同步 DUT / Execution 配置至数据库，返回对应的主键 ID。"""
+
+    global _LATEST_SYNC_RESULT
+    if not isinstance(config, dict) or not config:
+        logging.debug("skip sync_configuration: empty config")
+        return None
+    try:
+        with MySqlClient() as client:
+            synchronizer = ConfigSchemaSynchronizer(client)
+            result = synchronizer.sync(config)
+        _LATEST_SYNC_RESULT = result
+        logging.info(
+            "Synchronized configuration to database (dut_id=%s, execution_id=%s)",
+            result.dut_id,
+            result.execution_id,
+        )
+        return result
+    except Exception:
+        logging.exception("Failed to sync configuration to database")
+        return None
+
+
+def sync_test_result_to_db(
+    config: dict | None,
+    *,
+    log_file: str,
+    data_type: Optional[str] = None,
+    case_path: Optional[str] = None,
+) -> int:
+    """将性能测试日志写入按目录划分的结果表。"""
+
+    config = config or {}
+    sync_result = sync_configuration(config)
+    if sync_result is None:
+        logging.warning("Skip syncing test results because configuration sync failed.")
+        return 0
+
+    file_path = Path(log_file)
+    if not file_path.is_file():
+        logging.error("Log file %s not found, skip syncing test results.", log_file)
+        return 0
+
+    headers, rows = _read_csv_rows(file_path)
+    if not headers:
+        logging.warning("CSV file %s does not contain a header row, skip syncing.", log_file)
+        return 0
+
+    target_case_path = case_path or config.get("text_case")
+    table_name = _resolve_case_table_name(target_case_path, data_type)
+    context = TestResultContext(
+        dut_id=sync_result.dut_id,
+        execution_id=sync_result.execution_id,
+        case_path=target_case_path,
+        data_type=data_type,
+        log_file_path=file_path.resolve().as_posix(),
+    )
+
+    try:
+        with MySqlClient() as client:
+            manager = TestResultTableManager(client)
+            affected = manager.store_results(table_name, headers, rows, context)
+        return affected
+    except Exception:
+        logging.exception("Failed to sync test results into table %s", table_name)
+        return 0
+
+
 def sync_file_to_db(
     file_path: str,
     data_type: str,
     *,
-    overwrite: bool = True,
+    config: Optional[dict] = None,
+    case_path: Optional[str] = None,
 ) -> int:
-    client = MySqlClient()
-    try:
-        client.ensure_data_table()
-        row_count = client.import_csv(data_type, file_path, overwrite=overwrite)
-        return row_count
-    except Exception as exc:
-        logging.error("Failed to sync CSV file to database: %s", exc)
-        return 0
-    finally:
-        client.close()
+    """兼容旧入口的数据库写入接口。"""
+
+    resolved_config = config
+    if resolved_config is None:
+        try:
+            from src.tools.config_loader import load_config  # 延迟导入避免循环依赖
+        except Exception:
+            logging.exception("Failed to import load_config for database sync")
+            resolved_config = {}
+        else:
+            try:
+                resolved_config = load_config(refresh=True)
+            except Exception:
+                logging.exception("Failed to load configuration for database sync")
+                resolved_config = {}
+
+    return sync_test_result_to_db(
+        resolved_config or {},
+        log_file=file_path,
+        data_type=data_type,
+        case_path=case_path,
+    )
 
 
-__all__ = ["MySqlClient", "DataRecord", "sync_file_to_db"]
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
-    try:
-        with MySqlClient() as client:
-            client.ensure_data_table()
-            records = client.list_records(limit=5)
-            if not records:
-                logging.info("No records found in %s, inserting a sample row for local verification", DATA_TABLE_NAME)
-                sample_path = BASE_DIR / "sample_performance.csv"
-                with sample_path.open("w", newline="", encoding="utf-8") as sample_file:
-                    writer = csv.writer(sample_file)
-                    writer.writerow([csv_key for csv_key, _ in CSV_FIELD_MAP])
-                    writer.writerow([
-                        "SN0001",
-                        "RVR",
-                        "SubCase",
-                        "Standalone",
-                        "Null",
-                        "11AX",
-                        "5G",
-                        "80",
-                        "HE-160",
-                        "149",
-                        "TCP",
-                        "UL",
-                        "30",
-                        "-45",
-                        "-3",
-                        "-40",
-                        "15",
-                        "-55",
-                        "MCS9",
-                        "820",
-                        "780",
-                    ])
-                client.import_csv("SAMPLE", str(sample_path), overwrite=True)
-                sample_path.unlink(missing_ok=True)
-                records = client.list_records(limit=5)
-            for record in records:
-                logging.info(
-                    "Record %s | Type %s | File %s | Serial %s | Throughput %s",
-                    record.id,
-                    record.data_type,
-                    record.file_name,
-                    record.serial_number,
-                    record.throughput,
-                )
-    except RuntimeError as exc:
-        logging.error("MySQL client initialization failed: %s", exc)
+__all__ = [
+    "MySqlClient",
+    "sync_configuration",
+    "sync_test_result_to_db",
+    "sync_file_to_db",
+]


### PR DESCRIPTION
## Summary
- rebuild the MySQL sync layer to flatten DUT and execution config into dedicated tables and cascade identifiers into per-directory test result tables
- hook the existing save_config flow so every configuration change refreshes the database schema and stored values

## Testing
- python -m compileall src/tools/config_loader.py src/tools/mysql_tool/MySqlControl.py

------
https://chatgpt.com/codex/tasks/task_e_68e3aa276fb0832b92bc3ca5ab14bd3b